### PR TITLE
start rounds

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,5 @@
+alias Level10.Games
+alias Games.{Card, Game, Levels, Player}
+
+players = players = [Player.new("Player 1"), Player.new("Player 2"), Player.new("Player 3")]
+game = Game.new(players)

--- a/lib/level10/games/game.ex
+++ b/lib/level10/games/game.ex
@@ -38,7 +38,7 @@ defmodule Level10.Games.Game do
   def new(players) do
     %__MODULE__{
       complete: false,
-      current_round: 1,
+      current_round: 0,
       discard_pile: [],
       draw_pile: [],
       hands: %{},
@@ -46,38 +46,5 @@ defmodule Level10.Games.Game do
       scoring: %{},
       table: %{}
     }
-  end
-
-  @doc """
-  Creates a new shuffled deck for the draw pile.
-  """
-  @spec put_new_deck(t()) :: t()
-  def put_new_deck(game) do
-    %{game | draw_pile: new_deck()}
-  end
-
-  @spec new_deck() :: Card.t()
-  defp new_deck do
-    color_cards =
-      for value <- ~W[one two three four five six seven eight nine ten eleven twelve wild]a,
-          color <- ~W[blue green red yellow]a,
-          card = Card.new(value, color),
-          _repeat <- 1..2 do
-        card
-      end
-
-    skips = for _repeat <- 1..4, do: Card.new(:skip, :blue)
-
-    color_cards
-    |> Stream.concat(skips)
-    |> Enum.shuffle()
-  end
-
-  @doc """
-  Shuffles the discard pile to make a new draw pile.
-  """
-  @spec reshuffle_deck(t()) :: t()
-  def reshuffle_deck(game = %{discard_pile: discard_pile}) do
-    %{game | discard_pile: [], draw_pile: Enum.shuffle(discard_pile)}
   end
 end

--- a/lib/level10/games/games.ex
+++ b/lib/level10/games/games.ex
@@ -8,6 +8,58 @@ defmodule Level10.Games do
   alias Level10.Games.{Card, Game}
 
   @doc """
+  This function will make all of the necessary changes to start a round. It
+  will increment the current_round, shuffle a new deck of cards as the draw
+  pile, and deal out a new hand to each player.
+  """
+  @spec start_round(Game.t()) :: Game.t()
+  def start_round(game) do
+    game
+    |> increment_current_round()
+    |> put_new_deck()
+    |> put_new_hands()
+  end
+
+  @spec increment_current_round(Game.t()) :: Game.t()
+  defp increment_current_round(%{current_round: current_round} = game) do
+    %{game | current_round: current_round + 1}
+  end
+
+  @spec put_new_deck(Game.t()) :: Game.t()
+  defp put_new_deck(game) do
+    %{game | draw_pile: new_deck()}
+  end
+
+  @spec put_new_hands(Game.t()) :: Game.t()
+  defp put_new_hands(%{draw_pile: deck, players: players} = game) do
+    {hands, draw_pile} =
+      Enum.reduce(players, {%{}, deck}, fn %{name: player_name}, {hands, draw_pile} ->
+        {player_hand, rest_of_pile} = Enum.split(draw_pile, 10)
+        hands = Map.put(hands, player_name, player_hand)
+        {hands, rest_of_pile}
+      end)
+
+    %{game | draw_pile: draw_pile, hands: hands}
+  end
+
+  @spec new_deck() :: Card.t()
+  defp new_deck do
+    color_cards =
+      for value <- ~W[one two three four five six seven eight nine ten eleven twelve wild]a,
+          color <- ~W[blue green red yellow]a,
+          card = Card.new(value, color),
+          _repeat <- 1..2 do
+        card
+      end
+
+    skips = for _repeat <- 1..4, do: Card.new(:skip, :blue)
+
+    color_cards
+    |> Stream.concat(skips)
+    |> Enum.shuffle()
+  end
+
+  @doc """
   At the end of a round, the game struct should be passed into this function.
   It will update player scoring and levels, check if the game has been
   complete, and reset the state for the next round.
@@ -48,5 +100,14 @@ defmodule Level10.Games do
   @spec clear_round(Game.t()) :: Game.t()
   defp clear_round(game) do
     %{game | draw_pile: [], discard_pile: [], table: %{}, hands: %{}}
+  end
+
+  @doc """
+  Shuffles the discard pile to make a new draw pile. This should happen when
+  the current draw pile is empty.
+  """
+  @spec reshuffle_deck(Game.t()) :: Game.t()
+  def reshuffle_deck(game = %{discard_pile: discard_pile}) do
+    %{game | discard_pile: [], draw_pile: Enum.shuffle(discard_pile)}
   end
 end

--- a/test/level10/games_test.exs
+++ b/test/level10/games_test.exs
@@ -3,6 +3,29 @@ defmodule Level10.GamesTest do
   alias Level10.Games
   alias Games.{Card, Game, Player}
 
+  describe "start_round/1" do
+    @game Game.new([Player.new("Player 1"), Player.new("Player 2")])
+
+    test "increments the current_round" do
+      assert @game.current_round == 0
+      game = Games.start_round(@game)
+      assert game.current_round == 1
+    end
+
+    test "gives each player a hand with 10 cards" do
+      assert @game.hands == %{}
+      game = Games.start_round(@game)
+      assert length(game.hands["Player 1"]) == 10
+      assert length(game.hands["Player 2"]) == 10
+    end
+
+    test "attaches a new deck with 108 cards - 20 (for 2 hands)" do
+      assert @game.draw_pile == []
+      game = Games.start_round(@game)
+      assert length(game.draw_pile) == 88
+    end
+  end
+
   describe "complete_round/1" do
     @game Game.new([Player.new("Player 1"), Player.new("Player 2")])
     @hand_nothing [


### PR DESCRIPTION
This adds the functionality to start a new round. It will increment the
current round number within the game struct, shuffle and attach a new
deck to the draw pile, and then give each player a hand with 10 cards.

Additionally, I've included a .iex.exs file so that all of the current
modules will automatically be aliased when you run `iex -S mix` and you
will already have a list of players and a game generated for you to work
off of.