### PR TITLE
move game state to a vanilla genserver

### DIFF
--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -110,9 +110,7 @@ defmodule Level10.Games do
   end
 
   @spec finished?(Game.join_code()) :: boolean()
-  def finished?(join_code) do
-    GameServer.get(via(join_code), &(&1.current_stage == :finish))
-  end
+  defdelegate finished?(join_code), to: GameServer
 
   @doc """
   Returns the game with the specified join code.

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -405,14 +405,6 @@ defmodule Level10.Games do
   end
 
   @doc """
-  Start the next round.
-  """
-  @spec start_round(Game.join_code()) :: :ok | :game_over
-  def start_round(join_code) do
-    GenServer.call(via(join_code), :start_round, 5000)
-  end
-
-  @doc """
   Start the game.
   """
   @spec start_game(Game.join_code()) :: :ok

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -244,11 +244,7 @@ defmodule Level10.Games do
       nil
   """
   @spec get_top_discarded_card(Game.join_code()) :: Card.t() | nil
-  def get_top_discarded_card(join_code) do
-    GameServer.get(via(join_code), fn game ->
-      Game.top_discarded_card(game)
-    end)
-  end
+  defdelegate get_top_discarded_card(join_code), to: GameServer
 
   @doc """
   Attempts to join a game. Will return an ok tuple with the player ID for the

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -24,10 +24,7 @@ defmodule Level10.Games do
   Get the current count of active games in play.
   """
   @spec count() :: non_neg_integer()
-  def count() do
-    %{active: count} = Supervisor.count_children(GameSupervisor)
-    count
-  end
+  defdelegate count, to: GameServer
 
   @doc """
   Create a new game with the player named as its creator.

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -366,7 +366,7 @@ defmodule Level10.Games do
   """
   @spec mark_player_ready(Game.join_code(), Player.id()) :: :ok
   def mark_player_ready(join_code, player_id) do
-    result = GenServer.call(via(join_code), {:player_ready, player_id}, 5000)
+    result = GenServer.cast(via(join_code), {:player_ready, player_id})
     with :game_over <- result, do: delete_game(join_code)
   end
 

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -205,9 +205,7 @@ defmodule Level10.Games do
       }
   """
   @spec get_scores(Game.join_code()) :: Game.scores()
-  def get_scores(join_code) do
-    GameServer.get(via(join_code), & &1.scoring)
-  end
+  defdelegate get_scores(join_code), to: GameServer
 
   @doc """
   Get the table: the cards that have been played to complete levels by each

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -168,13 +168,7 @@ defmodule Level10.Games do
       }
   """
   @spec get_levels(Game.join_code()) :: %{optional(Player.t()) => Levels.level()}
-  def get_levels(join_code) do
-    levels = GameServer.get(via(join_code), & &1.levels)
-
-    for {player_id, level_number} <- levels,
-        into: %{},
-        do: {player_id, Levels.by_number(level_number)}
-  end
+  defdelegate get_levels(join_code), to: GameServer
 
   @doc """
   Get the list of players in a game.

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -1,39 +1,60 @@
 defmodule Level10.Games do
   @moduledoc """
-  This context module handles all of the work around running games. Most of the
-  functions will take in a game struct and manipulate that struct and return
-  it.
+  This module is the interface into game logic. All presenters within the web
+  domain should interface only with this module for controlling games. Its
+  children shouldn't be touched directly.
+
+  Most of the functions in the module are client functions that give
+  instructions to a game server, but some of them will interact instead with
+  the distributed registry and supervisor, or with Phoenix Presence or PubSub.
   """
 
-  alias Level10.Games.{Card, Game, GameServer, Levels, Player}
+  alias Level10.Presence
+  alias Level10.Games.{Game, GameRegistry, GameServer, GameSupervisor, Levels, Player}
   require Logger
 
-  @typep event_type :: atom()
+  @typep game_name :: {:via, module, term}
+
+  @max_creation_attempts 10
 
   @doc """
   Add one or more cards to a group that is already on the table
   """
   @spec add_to_table(Game.join_code(), Player.id(), Player.id(), non_neg_integer(), Game.cards()) ::
           :ok | :invalid_group | :level_incomplete | :needs_to_draw | :not_your_turn
-  defdelegate add_to_table(join_code, player_id, table_id, position, cards_to_add), to: GameServer
+  def add_to_table(join_code, player_id, table_id, position, cards_to_add) do
+    GenServer.call(
+      via(join_code),
+      {:add_to_table, {player_id, table_id, position, cards_to_add}},
+      5000
+    )
+  end
 
   @doc """
   Get the current count of active games in play.
   """
   @spec count() :: non_neg_integer()
-  defdelegate count, to: GameServer
+  def count do
+    %{active: count} = Supervisor.count_children(GameSupervisor)
+    count
+  end
 
   @doc """
   Create a new game with the player named as its creator.
   """
   @spec create_game(String.t()) :: {:ok, Game.join_code(), Player.id()} | :error
-  defdelegate create_game(player_name), to: GameServer
+  def create_game(player_name) do
+    player = Player.new(player_name)
+    do_create_game(player, @max_creation_attempts)
+  end
 
   @doc """
   Returns a Player struct representing the player who created the game.
   """
   @spec creator(Game.join_code()) :: Player.t()
-  defdelegate creator(join_code), to: GameServer
+  def creator(join_code) do
+    GenServer.call(via(join_code), :creator, 5000)
+  end
 
   @doc """
   Check to see if the current player has drawn a card yet.
@@ -44,7 +65,9 @@ defmodule Level10.Games do
       true
   """
   @spec current_player_has_drawn?(Game.join_code()) :: boolean()
-  defdelegate current_player_has_drawn?(join_code), to: GameServer
+  def current_player_has_drawn?(join_code) do
+    GenServer.call(via(join_code), :current_turn_drawn?, 5000)
+  end
 
   @doc """
   Delete a game.
@@ -54,8 +77,10 @@ defmodule Level10.Games do
       iex> delete_game("ABCD")
       :ok
   """
-  @spec delete_game(Game.join_code()) :: :ok
-  defdelegate delete_game(join_code), to: GameServer
+  @spec delete_game(Game.join_code(), reason :: term, timeout) :: :ok
+  def delete_game(join_code, reason \\ :normal, timeout \\ :infinity) do
+    GenServer.stop(via(join_code), reason, timeout)
+  end
 
   @doc """
   Discard a card from the player's hand
@@ -67,7 +92,9 @@ defmodule Level10.Games do
   """
   @spec discard_card(Game.join_code(), Player.id(), Card.t()) ::
           :ok | :needs_to_draw | :not_your_turn
-  defdelegate discard_card(join_code, player_id, card), to: GameServer
+  def discard_card(join_code, player_id, card) do
+    GenServer.call(via(join_code), {:discard, {player_id, card}}, 5000)
+  end
 
   @doc """
   Take the top card from either the draw pile or discard pile and add it to the
@@ -83,7 +110,9 @@ defmodule Level10.Games do
   """
   @spec draw_card(Game.join_code(), Player.id(), :discard_pile | :draw_pile) ::
           Card.t() | :already_drawn | :empty_discard_pile | :not_your_turn | :skip
-  defdelegate draw_card(join_code, player_id, source), to: GameServer
+  def draw_card(join_code, player_id, source) do
+    GenServer.call(via(join_code), {:draw, {player_id, source}}, 5000)
+  end
 
   @doc """
   Returns whether or not a game with the specified join code exists.
@@ -97,10 +126,25 @@ defmodule Level10.Games do
       false
   """
   @spec exists?(Game.join_code()) :: boolean()
-  defdelegate exists?(join_code), to: GameServer
+  def exists?(join_code) do
+    case Horde.Registry.lookup(GameRegistry, join_code) do
+      [] -> false
+      _ -> true
+    end
+  end
 
+  @doc """
+  Returns whether or not the specified game is finished.
+
+  ## Examples
+
+      iex> finished?("ABCD")
+      true
+  """
   @spec finished?(Game.join_code()) :: boolean()
-  defdelegate finished?(join_code), to: GameServer
+  def finished?(join_code) do
+    GenServer.call(via(join_code), :finished?, 5000)
+  end
 
   @doc """
   Returns the game with the specified join code.
@@ -111,7 +155,9 @@ defmodule Level10.Games do
       %Game{}
   """
   @spec get(Game.join_code()) :: Game.t()
-  defdelegate get(join_code), to: GameServer
+  def get(join_code) do
+    GenServer.call(via(join_code), :get, 5000)
+  end
 
   @doc """
   Get the player whose turn it currently is.
@@ -122,7 +168,9 @@ defmodule Level10.Games do
       %Player{id: "ffe6629a-faff-4053-b7b8-83c3a307400f", name: "Player 1"}
   """
   @spec get_current_turn(Game.join_code()) :: Player.t()
-  defdelegate get_current_turn(join_code), to: GameServer
+  def get_current_turn(join_code) do
+    GenServer.call(via(join_code), :current_player, 5000)
+  end
 
   @doc """
   Get the count of cards in each player's hand.
@@ -133,7 +181,9 @@ defmodule Level10.Games do
       %{"179539f0-661e-4b56-ac67-fec916214223" => 10, "000cc69a-bb7d-4d3e-ae9f-e42e3dcac23e" => 3}
   """
   @spec get_hand_counts(Game.join_code()) :: %{optional(Player.id()) => non_neg_integer()}
-  defdelegate get_hand_counts(join_code), to: GameServer
+  def get_hand_counts(join_code) do
+    GenServer.call(via(join_code), :hand_counts, 5000)
+  end
 
   @doc """
   Get the hand of the specified player.
@@ -144,7 +194,9 @@ defmodule Level10.Games do
       [%Card{color: :green, value: :twelve}, %Card{color: :blue, value: :nine}, ...]
   """
   @spec get_hand_for_player(Game.join_code(), Player.id()) :: list(Card.t())
-  defdelegate get_hand_for_player(join_code, player_id), to: GameServer
+  def get_hand_for_player(join_code, player_id) do
+    GenServer.call(via(join_code), {:hand, player_id}, 5000)
+  end
 
   @doc """
   Get the level information for each player in the game.
@@ -158,7 +210,13 @@ defmodule Level10.Games do
       }
   """
   @spec get_levels(Game.join_code()) :: %{optional(Player.t()) => Levels.level()}
-  defdelegate get_levels(join_code), to: GameServer
+  def get_levels(join_code) do
+    levels = GenServer.call(via(join_code), :levels, 5000)
+
+    for {player_id, level_number} <- levels,
+        into: %{},
+        do: {player_id, Levels.by_number(level_number)}
+  end
 
   @doc """
   Get the list of players in a game.
@@ -172,16 +230,25 @@ defmodule Level10.Games do
       ]
   """
   @spec get_players(Game.join_code()) :: list(Player.t())
-  defdelegate get_players(join_code), to: GameServer
+  def get_players(join_code) do
+    GenServer.call(via(join_code), :players, 5000)
+  end
 
   @doc """
   Gets the set of IDs of players who are ready for the next round to begin.
   """
   @spec get_players_ready(Game.join_code()) :: MapSet.t(Player.id())
-  defdelegate get_players_ready(join_code), to: GameServer
+  def get_players_ready(join_code) do
+    GenServer.call(via(join_code), :players_ready, 5000)
+  end
 
+  @doc """
+  Get the round number for the current round.
+  """
   @spec get_round_number(Game.join_code()) :: non_neg_integer()
-  defdelegate get_round_number(join_code), to: GameServer
+  def get_round_number(join_code) do
+    GenServer.call(via(join_code), :current_round, 5000)
+  end
 
   @doc """
   Get the scores for all players in a game.
@@ -195,7 +262,9 @@ defmodule Level10.Games do
       }
   """
   @spec get_scores(Game.join_code()) :: Game.scores()
-  defdelegate get_scores(join_code), to: GameServer
+  def get_scores(join_code) do
+    GenServer.call(via(join_code), :scoring, 5000)
+  end
 
   @doc """
   Get the table: the cards that have been played to complete levels by each
@@ -220,7 +289,9 @@ defmodule Level10.Games do
       }
   """
   @spec get_table(Game.join_code()) :: Game.table()
-  defdelegate get_table(join_code), to: GameServer
+  def get_table(join_code) do
+    GenServer.call(via(join_code), :table, 5000)
+  end
 
   @doc """
   Get the top card from the discard pile.
@@ -234,7 +305,9 @@ defmodule Level10.Games do
       nil
   """
   @spec get_top_discarded_card(Game.join_code()) :: Card.t() | nil
-  defdelegate get_top_discarded_card(join_code), to: GameServer
+  def get_top_discarded_card(join_code) do
+    GenServer.call(via(join_code), :top_discarded_card, 5000)
+  end
 
   @doc """
   Attempts to join a game. Will return an ok tuple with the player ID for the
@@ -256,7 +329,15 @@ defmodule Level10.Games do
   """
   @spec join_game(Game.join_code(), String.t()) ::
           {:ok, Player.id()} | :already_started | :full | :not_found
-  defdelegate join_game(join_code, player_name), to: GameServer
+  def join_game(join_code, player_name) do
+    player = Player.new(player_name)
+
+    if exists?(join_code) do
+      GenServer.call(via(join_code), {:join, player}, 5000)
+    else
+      :not_found
+    end
+  end
 
   @doc """
   Removes the specified player from the game. This is only allowed if the game
@@ -266,20 +347,38 @@ defmodule Level10.Games do
   well.
   """
   @spec leave_game(Game.join_code(), Player.id()) :: :ok | :already_started | :deleted
-  defdelegate leave_game(join_code, player_id), to: GameServer
+  def leave_game(join_code, player_id) do
+    result = GenServer.call(via(join_code), {:delete_player, player_id}, 5000)
+    with :empty_game <- result, do: delete_game(join_code)
+  end
+
+  @doc """
+  Get the list of players currently present in the specified game.
+  """
+  @spec list_presence(Game.join_code()) :: %{optional(Player.id()) => map()}
+  def list_presence(join_code) do
+    Presence.list("game:" <> join_code)
+  end
 
   @doc """
   Stores in the game state that the specified player is ready to move on to the
   next stage of the game.
   """
   @spec mark_player_ready(Game.join_code(), Player.id()) :: :ok
-  defdelegate mark_player_ready(join_code, player_id), to: GameServer
+  def mark_player_ready(join_code, player_id) do
+    result = GenServer.call(via(join_code), {:player_ready, player_id}, 5000)
+    with :game_over <- result, do: delete_game(join_code)
+  end
 
   @doc """
   Returns whether or not the specified player exists within the specified game.
   """
   @spec player_exists?(Game.t() | Game.join_code(), Player.id()) :: boolean()
-  defdelegate player_exists?(join_code, player_id), to: GameServer
+  def player_exists?(join_code, player_id) when is_binary(join_code) do
+    GenServer.call(via(join_code), {:player_exists?, player_id}, 5000)
+  end
+
+  def player_exists?(game, player_id), do: Game.player_exists?(game, player_id)
 
   @doc """
   Check whether or not the current round has started.
@@ -293,25 +392,33 @@ defmodule Level10.Games do
       false
   """
   @spec round_started?(Game.join_code()) :: boolean()
-  defdelegate round_started?(join_code), to: GameServer
+  def round_started?(join_code) do
+    GenServer.call(via(join_code), :round_started?, 5000)
+  end
 
   @doc """
   Returns the player struct representing the player who won the current round.
   """
   @spec round_winner(Game.join_code()) :: Player.t() | nil
-  defdelegate round_winner(join_code), to: GameServer
+  def round_winner(join_code) do
+    GenServer.call(via(join_code), :round_winner, 5000)
+  end
 
   @doc """
   Start the next round.
   """
   @spec start_round(Game.join_code()) :: :ok | :game_over
-  defdelegate start_round(join_code), to: GameServer
+  def start_round(join_code) do
+    GenServer.call(via(join_code), :start_round, 5000)
+  end
 
   @doc """
   Start the game.
   """
   @spec start_game(Game.join_code()) :: :ok | :single_player
-  defdelegate start_game(join_code), to: GameServer
+  def start_game(join_code) do
+    GenServer.call(via(join_code), :start_game, 5000)
+  end
 
   @doc """
   Check whether or not a game has started.
@@ -325,42 +432,84 @@ defmodule Level10.Games do
       false
   """
   @spec started?(Game.join_code()) :: boolean()
-  defdelegate started?(join_code), to: GameServer
+  def started?(join_code) do
+    GenServer.call(via(join_code), :started?, 5000)
+  end
+
+  @doc """
+  Susbscribe a process to updates for the specified game.
+  """
+  @spec subscribe(String.t(), Player.id()) :: :ok | {:error, term()}
+  def subscribe(game_code, player_id) do
+    topic = "game:" <> game_code
+
+    with :ok <- Phoenix.PubSub.subscribe(Level10.PubSub, topic),
+         {:ok, _} <- Presence.track_player(game_code, player_id) do
+      Presence.track_user(player_id, game_code)
+      :ok
+    end
+  end
 
   @doc """
   Set the given player's table to the given cards.
   """
   @spec table_cards(Game.join_code(), Player.id(), Game.player_table()) ::
           :ok | :already_set | :needs_to_draw | :not_your_turn
-  defdelegate table_cards(join_code, player_id, player_table), to: GameServer
-
-  @doc """
-  Susbscribe a process to updates for the specified game.
-  """
-  @spec subscribe(String.t(), Player.id()) :: :ok | {:error, term()}
-  defdelegate subscribe(game_code, player_id), to: GameServer
+  def table_cards(join_code, player_id, player_table) do
+    GenServer.call(via(join_code), {:table_cards, {player_id, player_table}}, 5000)
+  end
 
   @doc """
   Unsubscribe a process from updates for the specified game.
   """
   @spec unsubscribe(String.t(), Player.id()) :: :ok | {:error, term()}
-  defdelegate unsubscribe(game_code, player_id), to: GameServer
+  def unsubscribe(game_code, player_id) do
+    topic = "game:" <> game_code
+
+    with :ok <- Phoenix.PubSub.unsubscribe(Level10.PubSub, topic) do
+      Presence.untrack(self(), topic, player_id)
+    end
+  end
 
   @doc """
   Update the specified game using the provided function.
   """
   @spec update(Game.join_code(), (Game.t() -> Game.t())) :: :ok
-  defdelegate update(join_code, fun), to: GameServer
+  def update(join_code, fun) do
+    GenServer.call(via(join_code), {:update, fun}, 5000)
+  end
 
-  @doc """
-  Send an update to all the subscribed processes
-  """
-  @spec broadcast(Game.join_code(), event_type(), term()) :: :ok | {:error, term()}
-  defdelegate broadcast(join_code, event_type, event), to: GameServer
+  # Private
 
-  @doc """
-  Get the list of players currently present in the specified game.
-  """
-  @spec list_presence(Game.join_code()) :: %{optional(Player.id()) => map()}
-  defdelegate list_presence(join_code), to: GameServer
+  @spec do_create_game(Player.t(), non_neg_integer()) ::
+          {:ok, Game.join_code(), Player.id()} | :error
+  defp do_create_game(player, attempts_remaining)
+
+  defp do_create_game(_player, 0) do
+    :error
+  end
+
+  defp do_create_game(player, attempts_remaining) do
+    join_code = Game.generate_join_code()
+
+    game = %{
+      id: join_code,
+      start: {GameServer, :start_link, [{join_code, player}, [name: via(join_code)]]},
+      restart: :temporary
+    }
+
+    case Horde.DynamicSupervisor.start_child(GameSupervisor, game) do
+      {:ok, _pid} ->
+        Logger.info(["Created game ", join_code])
+        {:ok, join_code, player.id}
+
+      {:error, {:already_started, _pid}} ->
+        do_create_game(player, attempts_remaining - 1)
+    end
+  end
+
+  @spec via(Game.join_code()) :: game_name()
+  defp via(join_code) do
+    {:via, Horde.Registry, {GameRegistry, join_code}}
+  end
 end

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -340,11 +340,7 @@ defmodule Level10.Games do
       false
   """
   @spec started?(Game.join_code()) :: boolean()
-  def started?(join_code) do
-    GameServer.get(via(join_code), fn game ->
-      game.current_stage != :lobby
-    end)
-  end
+  defdelegate started?(join_code), to: GameServer
 
   @doc """
   Set the given player's table to the given cards.

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -349,25 +349,17 @@ defmodule Level10.Games do
           :ok | :already_set | :needs_to_draw | :not_your_turn
   defdelegate table_cards(join_code, player_id, player_table), to: GameServer
 
+  @doc """
+  Susbscribe a process to updates for the specified game.
+  """
   @spec subscribe(String.t(), Player.id()) :: :ok | {:error, term()}
-  def subscribe(game_code, player_id) do
-    topic = "game:" <> game_code
+  defdelegate subscribe(game_code, player_id), to: GameServer
 
-    with :ok <- Phoenix.PubSub.subscribe(Level10.PubSub, topic),
-         {:ok, _} <- Presence.track_player(game_code, player_id) do
-      Presence.track_user(player_id, game_code)
-      :ok
-    end
-  end
-
+  @doc """
+  Unsubscribe a process from updates for the specified game.
+  """
   @spec unsubscribe(String.t(), Player.id()) :: :ok | {:error, term()}
-  def unsubscribe(game_code, player_id) do
-    topic = "game:" <> game_code
-
-    with :ok <- Phoenix.PubSub.unsubscribe(Level10.PubSub, topic) do
-      Presence.untrack(self(), topic, player_id)
-    end
-  end
+  defdelegate unsubscribe(game_code, player_id), to: GameServer
 
   @spec update(Game.join_code(), (Game.t() -> Game.t())) :: :ok
   def update(join_code, fun) do

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -20,17 +20,7 @@ defmodule Level10.Games do
   """
   @spec add_to_table(Game.join_code(), Player.id(), Player.id(), non_neg_integer(), Game.cards()) ::
           :ok | :invalid_group | :level_incomplete | :needs_to_draw | :not_your_turn
-  def add_to_table(join_code, player_id, table_id, position, cards_to_add) do
-    GameServer.get_and_update(via(join_code), fn game ->
-      with {:ok, game} <-
-             Game.add_to_table(game, player_id, table_id, position, cards_to_add) do
-        broadcast(join_code, :hand_counts_updated, Game.hand_counts(game))
-        broadcast(join_code, :table_updated, game.table)
-
-        {:ok, maybe_complete_round(game, player_id)}
-      end
-    end)
-  end
+  defdelegate add_to_table(join_code, player_id, table_id, position, cards_to_add), to: GameServer
 
   @doc """
   Get the current count of active games in play.

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -290,12 +290,11 @@ defmodule Level10.Games do
   @spec mark_player_ready(Game.join_code(), Player.id()) :: :ok
   defdelegate mark_player_ready(join_code, player_id), to: GameServer
 
+  @doc """
+  Returns whether or not the specified player exists within the specified game.
+  """
   @spec player_exists?(Game.t() | Game.join_code(), Player.id()) :: boolean()
-  def player_exists?(join_code, player_id) when is_binary(join_code) do
-    GameServer.get(via(join_code), &Game.player_exists?(&1, player_id))
-  end
-
-  def player_exists?(game, player_id), do: Game.player_exists?(game, player_id)
+  defdelegate player_exists?(join_code, player_id), to: GameServer
 
   @doc """
   Check whether or not the current round has started.

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -13,7 +13,6 @@ defmodule Level10.Games do
   @typep game_name :: {:via, module, term}
 
   @max_attempts 10
-  @max_players 6
 
   @doc """
   Add one or more cards to a group that is already on the table
@@ -272,27 +271,7 @@ defmodule Level10.Games do
   """
   @spec join_game(Game.join_code(), String.t()) ::
           {:ok, Player.id()} | :already_started | :full | :not_found
-  def join_game(join_code, player_name) do
-    player = Player.new(player_name)
-
-    if exists?(join_code) do
-      GameServer.get_and_update(via(join_code), fn game ->
-        with {:ok, updated_game} <- Game.put_player(game, player),
-             true <- length(updated_game.players) <= @max_players do
-          broadcast(game.join_code, :players_updated, updated_game.players)
-          {{:ok, player.id}, updated_game}
-        else
-          :already_started ->
-            {:already_started, game}
-
-          _ ->
-            {:full, game}
-        end
-      end)
-    else
-      :not_found
-    end
-  end
+  defdelegate join_game(join_code, player_name), to: GameServer
 
   @spec leave_game(Game.join_code(), Player.id()) :: :ok | :already_started | :deleted
   def leave_game(join_code, player_id) do

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -132,9 +132,7 @@ defmodule Level10.Games do
       %Player{id: "ffe6629a-faff-4053-b7b8-83c3a307400f", name: "Player 1"}
   """
   @spec get_current_turn(Game.join_code()) :: Player.t()
-  def get_current_turn(join_code) do
-    GameServer.get(via(join_code), & &1.current_player)
-  end
+  defdelegate get_current_turn(join_code), to: GameServer
 
   @doc """
   Get the count of cards in each player's hand.

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -191,9 +191,7 @@ defmodule Level10.Games do
   defdelegate get_players_ready(join_code), to: GameServer
 
   @spec get_round_number(Game.join_code()) :: non_neg_integer()
-  def get_round_number(join_code) do
-    GameServer.get(via(join_code), & &1.current_round)
-  end
+  defdelegate get_round_number(join_code), to: GameServer
 
   @doc """
   Get the scores for all players in a game.

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -121,11 +121,7 @@ defmodule Level10.Games do
       %Game{}
   """
   @spec get(Game.join_code()) :: Game.t()
-  def get(join_code) do
-    join_code
-    |> via()
-    |> GameServer.get(& &1)
-  end
+  defdelegate get(join_code), to: GameServer
 
   @doc """
   Get the player whose turn it currently is.

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -182,9 +182,7 @@ defmodule Level10.Games do
       ]
   """
   @spec get_players(Game.join_code()) :: list(Player.t())
-  def get_players(join_code) do
-    GameServer.get(via(join_code), & &1.players)
-  end
+  defdelegate get_players(join_code), to: GameServer
 
   @doc """
   Gets the set of IDs of players who are ready for the next round to begin.

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -154,9 +154,7 @@ defmodule Level10.Games do
       [%Card{color: :green, value: :twelve}, %Card{color: :blue, value: :nine}, ...]
   """
   @spec get_hand_for_player(Game.join_code(), Player.id()) :: list(Card.t())
-  def get_hand_for_player(join_code, player_id) do
-    GameServer.get(via(join_code), & &1.hands[player_id])
-  end
+  defdelegate get_hand_for_player(join_code, player_id), to: GameServer
 
   @doc """
   Get the level information for each player in the game.

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -55,9 +55,7 @@ defmodule Level10.Games do
       true
   """
   @spec current_player_has_drawn?(Game.join_code()) :: boolean()
-  def current_player_has_drawn?(join_code) do
-    GameServer.get(via(join_code), & &1.current_turn_drawn?)
-  end
+  defdelegate current_player_has_drawn?(join_code), to: GameServer
 
   @doc """
   Delete a game.

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -83,8 +83,8 @@ defmodule Level10.Games do
   defdelegate discard_card(join_code, player_id, card), to: GameServer
 
   @doc """
-  Take the top card from either the draw pile or discard pile and returns add
-  it to the player's hand, returning the card
+  Take the top card from either the draw pile or discard pile and add it to the
+  player's hand
 
   ## Examples
 
@@ -96,20 +96,7 @@ defmodule Level10.Games do
   """
   @spec draw_card(Game.join_code(), Player.id(), :discard_pile | :draw_pile) ::
           Card.t() | :already_drawn | :empty_discard_pile | :not_your_turn | :skip
-  def draw_card(join_code, player_id, source) do
-    GameServer.get_and_update(via(join_code), fn game ->
-      with {:ok, game} <- Game.draw_card(game, player_id, source) do
-        if source == :discard_pile do
-          broadcast(join_code, :new_discard_top, Game.top_discarded_card(game))
-        end
-
-        broadcast(join_code, :hand_counts_updated, Game.hand_counts(game))
-        [new_card | _] = game.hands[player_id]
-
-        {new_card, game}
-      end
-    end)
-  end
+  defdelegate draw_card(join_code, player_id, source), to: GameServer
 
   @spec do_create_game(Player.t(), non_neg_integer()) ::
           {:ok, Game.join_code(), Player.id()} | :error

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -283,26 +283,12 @@ defmodule Level10.Games do
   @spec leave_game(Game.join_code(), Player.id()) :: :ok | :already_started | :deleted
   defdelegate leave_game(join_code, player_id), to: GameServer
 
+  @doc """
+  Stores in the game state that the specified player is ready to move on to the
+  next stage of the game.
+  """
   @spec mark_player_ready(Game.join_code(), Player.id()) :: :ok
-  def mark_player_ready(join_code, player_id) do
-    result =
-      GameServer.get_and_update(via(join_code), fn game ->
-        with {:all_ready, game} <- Game.mark_player_ready(game, player_id),
-             {:ok, game} <- Game.start_round(game) do
-          broadcast(join_code, :round_started, nil)
-          {:ok, game}
-        else
-          :game_over ->
-            {:game_over, game}
-
-          {:ok, game} ->
-            broadcast(join_code, :players_ready, game.players_ready)
-            {:ok, game}
-        end
-      end)
-
-    with :game_over <- result, do: delete_game(join_code)
-  end
+  defdelegate mark_player_ready(join_code, player_id), to: GameServer
 
   @spec player_exists?(Game.t() | Game.join_code(), Player.id()) :: boolean()
   def player_exists?(join_code, player_id) when is_binary(join_code) do

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -322,20 +322,11 @@ defmodule Level10.Games do
   @spec start_round(Game.join_code()) :: :ok | :game_over
   defdelegate start_round(join_code), to: GameServer
 
+  @doc """
+  Start the game.
+  """
   @spec start_game(Game.join_code()) :: :ok | :single_player
-  def start_game(join_code) do
-    GameServer.get_and_update(via(join_code), fn game ->
-      case Game.start_game(game) do
-        {:ok, game} ->
-          Logger.info("Started game #{join_code}")
-          broadcast(game.join_code, :game_started, nil)
-          {:ok, game}
-
-        :single_player ->
-          {:single_player, game}
-      end
-    end)
-  end
+  defdelegate start_game(join_code), to: GameServer
 
   @doc """
   Check whether or not a game has started.

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -31,19 +31,23 @@ defmodule Level10.Games do
     count
   end
 
+  @doc """
+  Create a new game with the player named as its creator.
+  """
   @spec create_game(String.t()) :: {:ok, Game.join_code(), Player.id()} | :error
   def create_game(player_name) do
     player = Player.new(player_name)
     do_create_game(player, @max_attempts)
   end
 
+  @doc """
+  Returns a Player struct representing the player who created the game.
+  """
   @spec creator(Game.join_code()) :: Player.t()
-  def creator(join_code) do
-    GameServer.get(via(join_code), &Game.creator/1)
-  end
+  defdelegate creator(join_code), to: GameServer
 
   @doc """
-  Check to see if the current player has drawn a card yet
+  Check to see if the current player has drawn a card yet.
 
   ## Examples
 

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -316,19 +316,11 @@ defmodule Level10.Games do
   @spec round_winner(Game.join_code()) :: Player.t() | nil
   defdelegate round_winner(join_code), to: GameServer
 
+  @doc """
+  Start the next round.
+  """
   @spec start_round(Game.join_code()) :: :ok | :game_over
-  def start_round(join_code) do
-    GameServer.get_and_update(via(join_code), fn game ->
-      case Game.start_round(game) do
-        {:ok, game} ->
-          broadcast(join_code, :round_started, nil)
-          {:ok, game}
-
-        :game_over ->
-          {:game_over, game}
-      end
-    end)
-  end
+  defdelegate start_round(join_code), to: GameServer
 
   @spec start_game(Game.join_code()) :: :ok | :single_player
   def start_game(join_code) do

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -188,9 +188,7 @@ defmodule Level10.Games do
   Gets the set of IDs of players who are ready for the next round to begin.
   """
   @spec get_players_ready(Game.join_code()) :: MapSet.t(Player.id())
-  def get_players_ready(join_code) do
-    GameServer.get(via(join_code), & &1.players_ready)
-  end
+  defdelegate get_players_ready(join_code), to: GameServer
 
   @spec get_round_number(Game.join_code()) :: non_neg_integer()
   def get_round_number(join_code) do

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -96,13 +96,19 @@ defmodule Level10.Games do
           Card.t() | :already_drawn | :empty_discard_pile | :not_your_turn | :skip
   defdelegate draw_card(join_code, player_id, source), to: GameServer
 
+  @doc """
+  Returns whether or not a game with the specified join code exists.
+
+  ## Examples
+
+      iex> exists?("ABCD")
+      true
+
+      iex> exists?("ASDF")
+      false
+  """
   @spec exists?(Game.join_code()) :: boolean()
-  def exists?(join_code) do
-    case Horde.Registry.lookup(GameRegistry, join_code) do
-      [] -> false
-      _ -> true
-    end
-  end
+  defdelegate exists?(join_code), to: GameServer
 
   @spec via(Game.join_code()) :: game_name()
   defp via(join_code) do

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -308,11 +308,7 @@ defmodule Level10.Games do
       false
   """
   @spec round_started?(Game.join_code()) :: boolean()
-  def round_started?(join_code) do
-    GameServer.get(via(join_code), fn game ->
-      game.current_stage == :play
-    end)
-  end
+  defdelegate round_started?(join_code), to: GameServer
 
   @spec round_winner(Game.join_code()) :: Player.t() | nil
   def round_winner(join_code) do

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -475,12 +475,12 @@ defmodule Level10.Games do
   end
 
   @doc """
-  Update the specified game using the provided function.
+  Update the specified game using the provided function. This isn't meant to be
+  used for anything other than administrative debugging.
   """
   @spec update(Game.join_code(), (Game.t() -> Game.t())) :: :ok
   def update(join_code, fun) do
-    # TODO: Move this to cast
-    GenServer.call(via(join_code), {:update, fun}, 5000)
+    GenServer.cast(via(join_code), {:update, fun})
   end
 
   # Private

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -143,9 +143,7 @@ defmodule Level10.Games do
       %{"179539f0-661e-4b56-ac67-fec916214223" => 10, "000cc69a-bb7d-4d3e-ae9f-e42e3dcac23e" => 3}
   """
   @spec get_hand_counts(Game.join_code()) :: %{optional(Player.id()) => non_neg_integer()}
-  def get_hand_counts(join_code) do
-    GameServer.get(via(join_code), &Game.hand_counts/1)
-  end
+  defdelegate get_hand_counts(join_code), to: GameServer
 
   @doc """
   Get the hand of the specified player.

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -20,13 +20,20 @@ defmodule Level10.Games do
   @doc """
   Add one or more cards to a group that is already on the table
   """
-  @spec add_to_table(Game.join_code(), Player.id(), Player.id(), non_neg_integer(), Game.cards()) ::
+  @spec add_to_table(
+          Game.join_code(),
+          Player.id(),
+          Player.id(),
+          non_neg_integer(),
+          Game.cards(),
+          timeout()
+        ) ::
           :ok | :invalid_group | :level_incomplete | :needs_to_draw | :not_your_turn
-  def add_to_table(join_code, player_id, table_id, position, cards_to_add) do
+  def add_to_table(join_code, player_id, table_id, position, cards_to_add, timeout \\ 5000) do
     GenServer.call(
       via(join_code),
       {:add_to_table, {player_id, table_id, position, cards_to_add}},
-      5000
+      timeout
     )
   end
 
@@ -51,9 +58,9 @@ defmodule Level10.Games do
   @doc """
   Returns a Player struct representing the player who created the game.
   """
-  @spec creator(Game.join_code()) :: Player.t()
-  def creator(join_code) do
-    GenServer.call(via(join_code), :creator, 5000)
+  @spec creator(Game.join_code(), timeout()) :: Player.t()
+  def creator(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :creator, timeout)
   end
 
   @doc """
@@ -64,9 +71,9 @@ defmodule Level10.Games do
       iex> current_player_has_drawn?("ABCD")
       true
   """
-  @spec current_player_has_drawn?(Game.join_code()) :: boolean()
-  def current_player_has_drawn?(join_code) do
-    GenServer.call(via(join_code), :current_turn_drawn?, 5000)
+  @spec current_player_has_drawn?(Game.join_code(), timeout()) :: boolean()
+  def current_player_has_drawn?(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :current_turn_drawn?, timeout)
   end
 
   @doc """
@@ -90,10 +97,10 @@ defmodule Level10.Games do
       iex> discard_card("ABCD", "9c34b9fe-3104-44b3-b21b-28140e2e3624", %Card{color: :green, value: :twelve})
       :ok
   """
-  @spec discard_card(Game.join_code(), Player.id(), Card.t()) ::
+  @spec discard_card(Game.join_code(), Player.id(), Card.t(), timeout()) ::
           :ok | :needs_to_draw | :not_your_turn
-  def discard_card(join_code, player_id, card) do
-    GenServer.call(via(join_code), {:discard, {player_id, card}}, 5000)
+  def discard_card(join_code, player_id, card, timeout \\ 5000) do
+    GenServer.call(via(join_code), {:discard, {player_id, card}}, timeout)
   end
 
   @doc """
@@ -108,10 +115,10 @@ defmodule Level10.Games do
       iex> draw_card("ABCD", "9c34b9fe-3104-44b3-b21b-28140e2e3624", :discard_pile)
       %Card{color: :green, value: :twelve}
   """
-  @spec draw_card(Game.join_code(), Player.id(), :discard_pile | :draw_pile) ::
+  @spec draw_card(Game.join_code(), Player.id(), :discard_pile | :draw_pile, timeout()) ::
           Card.t() | :already_drawn | :empty_discard_pile | :not_your_turn | :skip
-  def draw_card(join_code, player_id, source) do
-    GenServer.call(via(join_code), {:draw, {player_id, source}}, 5000)
+  def draw_card(join_code, player_id, source, timeout \\ 5000) do
+    GenServer.call(via(join_code), {:draw, {player_id, source}}, timeout)
   end
 
   @doc """
@@ -141,9 +148,9 @@ defmodule Level10.Games do
       iex> finished?("ABCD")
       true
   """
-  @spec finished?(Game.join_code()) :: boolean()
-  def finished?(join_code) do
-    GenServer.call(via(join_code), :finished?, 5000)
+  @spec finished?(Game.join_code(), timeout()) :: boolean()
+  def finished?(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :finished?, timeout)
   end
 
   @doc """
@@ -154,9 +161,9 @@ defmodule Level10.Games do
       iex> get("ABCD")
       %Game{}
   """
-  @spec get(Game.join_code()) :: Game.t()
-  def get(join_code) do
-    GenServer.call(via(join_code), :get, 5000)
+  @spec get(Game.join_code(), timeout()) :: Game.t()
+  def get(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :get, timeout)
   end
 
   @doc """
@@ -167,9 +174,9 @@ defmodule Level10.Games do
       iex> get_current_turn("ABCD")
       %Player{id: "ffe6629a-faff-4053-b7b8-83c3a307400f", name: "Player 1"}
   """
-  @spec get_current_turn(Game.join_code()) :: Player.t()
-  def get_current_turn(join_code) do
-    GenServer.call(via(join_code), :current_player, 5000)
+  @spec get_current_turn(Game.join_code(), timeout()) :: Player.t()
+  def get_current_turn(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :current_player, timeout)
   end
 
   @doc """
@@ -180,9 +187,11 @@ defmodule Level10.Games do
       iex> get_hand_counts("ABCD")
       %{"179539f0-661e-4b56-ac67-fec916214223" => 10, "000cc69a-bb7d-4d3e-ae9f-e42e3dcac23e" => 3}
   """
-  @spec get_hand_counts(Game.join_code()) :: %{optional(Player.id()) => non_neg_integer()}
-  def get_hand_counts(join_code) do
-    GenServer.call(via(join_code), :hand_counts, 5000)
+  @spec get_hand_counts(Game.join_code(), timeout()) :: %{
+          optional(Player.id()) => non_neg_integer()
+        }
+  def get_hand_counts(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :hand_counts, timeout)
   end
 
   @doc """
@@ -193,9 +202,9 @@ defmodule Level10.Games do
       iex> get_hand_for_player("ABCD", "557489d0-1ef2-4763-9b0b-d2ea3c80fd99")
       [%Card{color: :green, value: :twelve}, %Card{color: :blue, value: :nine}, ...]
   """
-  @spec get_hand_for_player(Game.join_code(), Player.id()) :: list(Card.t())
-  def get_hand_for_player(join_code, player_id) do
-    GenServer.call(via(join_code), {:hand, player_id}, 5000)
+  @spec get_hand_for_player(Game.join_code(), Player.id(), timeout()) :: list(Card.t())
+  def get_hand_for_player(join_code, player_id, timeout \\ 5000) do
+    GenServer.call(via(join_code), {:hand, player_id}, timeout)
   end
 
   @doc """
@@ -209,9 +218,9 @@ defmodule Level10.Games do
         "86800484-8e73-4408-bd15-98a57871694f" => [run: 7],
       }
   """
-  @spec get_levels(Game.join_code()) :: %{optional(Player.t()) => Levels.level()}
-  def get_levels(join_code) do
-    levels = GenServer.call(via(join_code), :levels, 5000)
+  @spec get_levels(Game.join_code(), timeout()) :: %{optional(Player.t()) => Levels.level()}
+  def get_levels(join_code, timeout \\ 5000) do
+    levels = GenServer.call(via(join_code), :levels, timeout)
 
     for {player_id, level_number} <- levels,
         into: %{},
@@ -229,25 +238,25 @@ defmodule Level10.Games do
         %Player{id: "a0d2ef3e-e44c-4a58-b90d-a56d88224700", name: "Player 2"}
       ]
   """
-  @spec get_players(Game.join_code()) :: list(Player.t())
-  def get_players(join_code) do
-    GenServer.call(via(join_code), :players, 5000)
+  @spec get_players(Game.join_code(), timeout) :: list(Player.t())
+  def get_players(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :players, timeout)
   end
 
   @doc """
   Gets the set of IDs of players who are ready for the next round to begin.
   """
-  @spec get_players_ready(Game.join_code()) :: MapSet.t(Player.id())
-  def get_players_ready(join_code) do
-    GenServer.call(via(join_code), :players_ready, 5000)
+  @spec get_players_ready(Game.join_code(), timeout()) :: MapSet.t(Player.id())
+  def get_players_ready(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :players_ready, timeout)
   end
 
   @doc """
   Get the round number for the current round.
   """
-  @spec get_round_number(Game.join_code()) :: non_neg_integer()
-  def get_round_number(join_code) do
-    GenServer.call(via(join_code), :current_round, 5000)
+  @spec get_round_number(Game.join_code(), timeout()) :: non_neg_integer()
+  def get_round_number(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :current_round, timeout)
   end
 
   @doc """
@@ -261,9 +270,9 @@ defmodule Level10.Games do
         "38379e46-4d29-4a22-a245-aa7013ec3c33" => {2, 120}
       }
   """
-  @spec get_scores(Game.join_code()) :: Game.scores()
-  def get_scores(join_code) do
-    GenServer.call(via(join_code), :scoring, 5000)
+  @spec get_scores(Game.join_code(), timeout()) :: Game.scores()
+  def get_scores(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :scoring, timeout)
   end
 
   @doc """
@@ -288,9 +297,9 @@ defmodule Level10.Games do
         }
       }
   """
-  @spec get_table(Game.join_code()) :: Game.table()
-  def get_table(join_code) do
-    GenServer.call(via(join_code), :table, 5000)
+  @spec get_table(Game.join_code(), timeout()) :: Game.table()
+  def get_table(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :table, timeout)
   end
 
   @doc """
@@ -304,9 +313,9 @@ defmodule Level10.Games do
       iex> get_top_discarded_card("ABCD")
       nil
   """
-  @spec get_top_discarded_card(Game.join_code()) :: Card.t() | nil
-  def get_top_discarded_card(join_code) do
-    GenServer.call(via(join_code), :top_discarded_card, 5000)
+  @spec get_top_discarded_card(Game.join_code(), timeout()) :: Card.t() | nil
+  def get_top_discarded_card(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :top_discarded_card, timeout)
   end
 
   @doc """
@@ -327,13 +336,13 @@ defmodule Level10.Games do
       iex> join_game("ABCD", "Player One")
       :not_found
   """
-  @spec join_game(Game.join_code(), String.t()) ::
+  @spec join_game(Game.join_code(), String.t(), timeout()) ::
           {:ok, Player.id()} | :already_started | :full | :not_found
-  def join_game(join_code, player_name) do
+  def join_game(join_code, player_name, timeout \\ 5000) do
     player = Player.new(player_name)
 
     if exists?(join_code) do
-      GenServer.call(via(join_code), {:join, player}, 5000)
+      GenServer.call(via(join_code), {:join, player}, timeout)
     else
       :not_found
     end
@@ -346,9 +355,9 @@ defmodule Level10.Games do
   If the player is currently alone in the game, the game will be deleted as
   well.
   """
-  @spec leave_game(Game.join_code(), Player.id()) :: :ok | :already_started | :deleted
-  def leave_game(join_code, player_id) do
-    result = GenServer.call(via(join_code), {:delete_player, player_id}, 5000)
+  @spec leave_game(Game.join_code(), Player.id(), timeout()) :: :ok | :already_started | :deleted
+  def leave_game(join_code, player_id, timeout \\ 5000) do
+    result = GenServer.call(via(join_code), {:delete_player, player_id}, timeout)
     with :empty_game <- result, do: delete_game(join_code)
   end
 
@@ -373,12 +382,14 @@ defmodule Level10.Games do
   @doc """
   Returns whether or not the specified player exists within the specified game.
   """
-  @spec player_exists?(Game.t() | Game.join_code(), Player.id()) :: boolean()
-  def player_exists?(join_code, player_id) when is_binary(join_code) do
-    GenServer.call(via(join_code), {:player_exists?, player_id}, 5000)
+  @spec player_exists?(Game.t() | Game.join_code(), Player.id(), timeout()) :: boolean()
+  def player_exists?(join_code_or_game, player_id, timeout \\ 5000)
+
+  def player_exists?(join_code, player_id, timeout) when is_binary(join_code) do
+    GenServer.call(via(join_code), {:player_exists?, player_id}, timeout)
   end
 
-  def player_exists?(game, player_id), do: Game.player_exists?(game, player_id)
+  def player_exists?(game, player_id, _), do: Game.player_exists?(game, player_id)
 
   @doc """
   Check whether or not the current round has started.
@@ -391,17 +402,17 @@ defmodule Level10.Games do
       iex> round_started?("EFGH")
       false
   """
-  @spec round_started?(Game.join_code()) :: boolean()
-  def round_started?(join_code) do
-    GenServer.call(via(join_code), :round_started?, 5000)
+  @spec round_started?(Game.join_code(), timeout()) :: boolean()
+  def round_started?(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :round_started?, timeout)
   end
 
   @doc """
   Returns the player struct representing the player who won the current round.
   """
-  @spec round_winner(Game.join_code()) :: Player.t() | nil
-  def round_winner(join_code) do
-    GenServer.call(via(join_code), :round_winner, 5000)
+  @spec round_winner(Game.join_code(), timeout()) :: Player.t() | nil
+  def round_winner(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :round_winner, timeout)
   end
 
   @doc """
@@ -423,9 +434,9 @@ defmodule Level10.Games do
       iex> started?("EFGH")
       false
   """
-  @spec started?(Game.join_code()) :: boolean()
-  def started?(join_code) do
-    GenServer.call(via(join_code), :started?, 5000)
+  @spec started?(Game.join_code(), timeout()) :: boolean()
+  def started?(join_code, timeout \\ 5000) do
+    GenServer.call(via(join_code), :started?, timeout)
   end
 
   @doc """
@@ -445,10 +456,10 @@ defmodule Level10.Games do
   @doc """
   Set the given player's table to the given cards.
   """
-  @spec table_cards(Game.join_code(), Player.id(), Game.player_table()) ::
+  @spec table_cards(Game.join_code(), Player.id(), Game.player_table(), timeout()) ::
           :ok | :already_set | :needs_to_draw | :not_your_turn
-  def table_cards(join_code, player_id, player_table) do
-    GenServer.call(via(join_code), {:table_cards, {player_id, player_table}}, 5000)
+  def table_cards(join_code, player_id, player_table, timeout \\ 5000) do
+    GenServer.call(via(join_code), {:table_cards, {player_id, player_table}}, timeout)
   end
 
   @doc """
@@ -468,6 +479,7 @@ defmodule Level10.Games do
   """
   @spec update(Game.join_code(), (Game.t() -> Game.t())) :: :ok
   def update(join_code, fun) do
+    # TODO: Move this to cast
     GenServer.call(via(join_code), {:update, fun}, 5000)
   end
 

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -80,25 +80,7 @@ defmodule Level10.Games do
   """
   @spec discard_card(Game.join_code(), Player.id(), Card.t()) ::
           :ok | :needs_to_draw | :not_your_turn
-  def discard_card(join_code, player_id, card) do
-    GameServer.get_and_update(via(join_code), fn game ->
-      with ^player_id <- game.current_player.id,
-           %Game{} = game <- Game.discard(game, card) do
-        broadcast(join_code, :hand_counts_updated, Game.hand_counts(game))
-        broadcast(join_code, :new_discard_top, card)
-
-        if Game.round_finished?(game, player_id) do
-          {:ok, maybe_complete_round(game, player_id)}
-        else
-          broadcast(join_code, :new_turn, game.current_player)
-          {:ok, game}
-        end
-      else
-        :needs_to_draw -> :needs_to_draw
-        _ -> :not_your_turn
-      end
-    end)
-  end
+  defdelegate discard_card(join_code, player_id, card), to: GameServer
 
   @doc """
   Take the top card from either the draw pile or discard pile and returns add

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -361,10 +361,11 @@ defmodule Level10.Games do
   @spec unsubscribe(String.t(), Player.id()) :: :ok | {:error, term()}
   defdelegate unsubscribe(game_code, player_id), to: GameServer
 
+  @doc """
+  Update the specified game using the provided function.
+  """
   @spec update(Game.join_code(), (Game.t() -> Game.t())) :: :ok
-  def update(join_code, fun) do
-    GameServer.update(via(join_code), fun)
-  end
+  defdelegate update(join_code, fun), to: GameServer
 
   @spec broadcast(Game.join_code(), event_type(), term()) :: :ok | {:error, term()}
   def broadcast(join_code, event_type, event) do

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -415,9 +415,9 @@ defmodule Level10.Games do
   @doc """
   Start the game.
   """
-  @spec start_game(Game.join_code()) :: :ok | :single_player
+  @spec start_game(Game.join_code()) :: :ok
   def start_game(join_code) do
-    GenServer.call(via(join_code), :start_game, 5000)
+    GenServer.cast(via(join_code), :start_game)
   end
 
   @doc """

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -273,25 +273,15 @@ defmodule Level10.Games do
           {:ok, Player.id()} | :already_started | :full | :not_found
   defdelegate join_game(join_code, player_name), to: GameServer
 
+  @doc """
+  Removes the specified player from the game. This is only allowed if the game
+  is still in the lobby stage.
+
+  If the player is currently alone in the game, the game will be deleted as
+  well.
+  """
   @spec leave_game(Game.join_code(), Player.id()) :: :ok | :already_started | :deleted
-  def leave_game(join_code, player_id) do
-    result =
-      GameServer.get_and_update(via(join_code), fn game ->
-        case Game.delete_player(game, player_id) do
-          {:ok, game} ->
-            broadcast(game.join_code, :players_updated, game.players)
-            {:ok, game}
-
-          :already_started ->
-            {:already_started, game}
-
-          :empty_game ->
-            {:empty_game, game}
-        end
-      end)
-
-    with :empty_game <- result, do: delete_game(join_code)
-  end
+  defdelegate leave_game(join_code, player_id), to: GameServer
 
   @spec mark_player_ready(Game.join_code(), Player.id()) :: :ok
   def mark_player_ready(join_code, player_id) do

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -6,7 +6,6 @@ defmodule Level10.Games do
   """
 
   alias Level10.Games.{Card, Game, GameRegistry, GameServer, GameSupervisor, Levels, Player}
-  alias Level10.Presence
   require Logger
 
   @typep event_type :: atom()
@@ -367,15 +366,17 @@ defmodule Level10.Games do
   @spec update(Game.join_code(), (Game.t() -> Game.t())) :: :ok
   defdelegate update(join_code, fun), to: GameServer
 
+  @doc """
+  Send an update to all the subscribed processes
+  """
   @spec broadcast(Game.join_code(), event_type(), term()) :: :ok | {:error, term()}
-  def broadcast(join_code, event_type, event) do
-    Phoenix.PubSub.broadcast(Level10.PubSub, "game:" <> join_code, {event_type, event})
-  end
+  defdelegate broadcast(join_code, event_type, event), to: GameServer
 
+  @doc """
+  Get the list of players currently present in the specified game.
+  """
   @spec list_presence(Game.join_code()) :: %{optional(Player.id()) => map()}
-  def list_presence(join_code) do
-    Presence.list("game:" <> join_code)
-  end
+  defdelegate list_presence(join_code), to: GameServer
 
   # Private
 

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -310,12 +310,11 @@ defmodule Level10.Games do
   @spec round_started?(Game.join_code()) :: boolean()
   defdelegate round_started?(join_code), to: GameServer
 
+  @doc """
+  Returns the player struct representing the player who won the current round.
+  """
   @spec round_winner(Game.join_code()) :: Player.t() | nil
-  def round_winner(join_code) do
-    GameServer.get(via(join_code), fn game ->
-      Game.round_winner(game)
-    end)
-  end
+  defdelegate round_winner(join_code), to: GameServer
 
   @spec start_round(Game.join_code()) :: :ok | :game_over
   def start_round(join_code) do

--- a/lib/level10/games.ex
+++ b/lib/level10/games.ex
@@ -230,9 +230,7 @@ defmodule Level10.Games do
       }
   """
   @spec get_table(Game.join_code()) :: Game.table()
-  def get_table(join_code) do
-    GameServer.get(via(join_code), & &1.table)
-  end
+  defdelegate get_table(join_code), to: GameServer
 
   @doc """
   Get the top card from the discard pile.

--- a/lib/level10/games/game.ex
+++ b/lib/level10/games/game.ex
@@ -61,7 +61,7 @@ defmodule Level10.Games.Game do
       {:ok, %Game{}}
   """
   @spec add_to_table(t(), Player.id(), Player.id(), non_neg_integer(), Game.cards()) ::
-          {:ok | :invalid_group | :level_incomplete | :needs_to_draw | :not_your_turn, t()}
+          t() | :invalid_group | :level_incomplete | :needs_to_draw | :not_your_turn
   def add_to_table(game, current_player_id, group_player_id, position, cards_to_add) do
     # get the level requirement for the specified group
     requirement = group_requirement(game, group_player_id, position)
@@ -79,20 +79,11 @@ defmodule Level10.Games.Game do
       hands = %{game.hands | current_player_id => game.hands[current_player_id] -- cards_to_add}
       {:ok, %{game | hands: hands, table: table}}
     else
-      nil ->
-        {:invalid_group, game}
-
-      false ->
-        {:invalid_group, game}
-
-      {:current_turn_drawn?, _} ->
-        {:needs_to_draw, game}
-
-      {:level_complete?, _} ->
-        {:level_incomplete, game}
-
-      player_id when is_binary(player_id) ->
-        {:not_your_turn, game}
+      nil -> :invalid_group
+      false -> :invalid_group
+      {:current_turn_drawn?, _} -> :needs_to_draw
+      {:level_complete?, _} -> :level_incomplete
+      player_id when is_binary(player_id) -> :not_your_turn
     end
   end
 
@@ -370,7 +361,7 @@ defmodule Level10.Games.Game do
   Set a player's table to the given cards
   """
   @spec set_player_table(t(), Player.id(), player_table()) ::
-          {:ok | :already_set | :invalid_level | :needs_to_draw | :not_your_turn, t()}
+          t() | :already_set | :invalid_level | :needs_to_draw | :not_your_turn
   def set_player_table(game, player_id, player_table) do
     with ^player_id <- game.current_player.id,
          {:drawn, true} <- {:drawn, game.current_turn_drawn?},
@@ -385,12 +376,12 @@ defmodule Level10.Games.Game do
       cards_used = Enum.reduce(player_table, [], fn {_, cards}, acc -> acc ++ cards end)
       player_hand = game.hands[player_id] -- cards_used
       hands = Map.put(game.hands, player_id, player_hand)
-      {:ok, %{game | hands: hands, table: table}}
+      %{game | hands: hands, table: table}
     else
-      player_id when is_binary(player_id) -> {:not_your_turn, game}
-      false -> {:invalid_level, game}
-      {:drawn, false} -> {:needs_to_draw, game}
-      _ -> {:already_set, game}
+      player_id when is_binary(player_id) -> :not_your_turn
+      false -> :invalid_level
+      {:drawn, false} -> :needs_to_draw
+      _ -> :already_set
     end
   end
 

--- a/lib/level10/games/game.ex
+++ b/lib/level10/games/game.ex
@@ -212,20 +212,20 @@ defmodule Level10.Games.Game do
           {:ok | :already_drawn | :empty_discard_pile | :not_your_turn | :skip, t()}
   def draw_card(game, player_id, pile)
 
-  def draw_card(game = %{current_player: %{id: current_id}}, player_id, _)
+  def draw_card(%{current_player: %{id: current_id}}, player_id, _)
       when current_id != player_id do
-    {:not_your_turn, game}
+    :not_your_turn
   end
 
-  def draw_card(game = %{current_turn_drawn?: true}, _player_id, _pile) do
-    {:already_drawn, game}
+  def draw_card(%{current_turn_drawn?: true}, _player_id, _pile) do
+    :already_drawn
   end
 
   def draw_card(game = %{draw_pile: pile, hands: hands}, player_id, :draw_pile) do
     case pile do
       [card | pile] ->
         hands = Map.update!(hands, player_id, &[card | &1])
-        {:ok, %{game | current_turn_drawn?: true, draw_pile: pile, hands: hands}}
+        %{game | current_turn_drawn?: true, draw_pile: pile, hands: hands}
 
       [] ->
         game
@@ -234,18 +234,18 @@ defmodule Level10.Games.Game do
     end
   end
 
-  def draw_card(game = %{discard_pile: []}, _player_id, :discard_pile) do
-    {:empty_discard_pile, game}
+  def draw_card(%{discard_pile: []}, _player_id, :discard_pile) do
+    :empty_discard_pile
   end
 
-  def draw_card(game = %{discard_pile: [%{value: :skip} | _]}, _player_id, :discard_pile) do
-    {:skip, game}
+  def draw_card(%{discard_pile: [%{value: :skip} | _]}, _player_id, :discard_pile) do
+    :skip
   end
 
   def draw_card(game, player_id, :discard_pile) do
     %{discard_pile: [card | pile], hands: hands} = game
     hands = Map.update!(hands, player_id, &[card | &1])
-    {:ok, %{game | current_turn_drawn?: true, discard_pile: pile, hands: hands}}
+    %{game | current_turn_drawn?: true, discard_pile: pile, hands: hands}
   end
 
   @doc """

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -384,6 +384,14 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), :round_started?, 5000)
   end
 
+  @doc """
+  Returns the player struct representing the player who won the current round.
+  """
+  @spec round_winner(Game.join_code()) :: Player.t() | nil
+  def round_winner(join_code) do
+    GenServer.call(via(join_code), :round_winner, 5000)
+  end
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -598,6 +606,10 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:round_started?, _from, game) do
     {:reply, game.current_stage == :play, game}
+  end
+
+  def handle_call(:round_winner, _from, game) do
+    {:reply, Game.round_winner(game), game}
   end
 
   def handle_call(:scoring, _from, game) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -5,7 +5,7 @@ defmodule Level10.Games.GameServer do
 
   use GenServer
   alias Level10.{Presence, StateHandoff}
-  alias Level10.Games.{Game, GameRegistry, Levels, Player}
+  alias Level10.Games.{Game, GameRegistry, GameSupervisor, Levels, Player}
   require Logger
 
   # Types
@@ -50,6 +50,15 @@ defmodule Level10.Games.GameServer do
   @spec broadcast(Game.join_code(), event_type(), term()) :: :ok | {:error, term()}
   def broadcast(join_code, event_type, event) do
     Phoenix.PubSub.broadcast(Level10.PubSub, "game:" <> join_code, {event_type, event})
+  end
+
+  @doc """
+  Get the current count of active games in play.
+  """
+  @spec count() :: non_neg_integer()
+  def count() do
+    %{active: count} = Supervisor.count_children(GameSupervisor)
+    count
   end
 
   @doc """

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -221,6 +221,22 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), :current_round, 5000)
   end
 
+  @doc """
+  Get the scores for all players in a game.
+
+  ## Examples
+
+      iex> get_scores("ABCD")
+      %{
+        "e486056e-4a01-4239-9f00-6f7f57ca8d54" => {3, 55},
+        "38379e46-4d29-4a22-a245-aa7013ec3c33" => {2, 120}
+      }
+  """
+  @spec get_scores(Game.join_code()) :: Game.scores()
+  def get_scores(join_code) do
+    GenServer.call(via(join_code), :scoring, 5000)
+  end
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -381,6 +397,10 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:players_ready, _from, game) do
     {:reply, game.players_ready, game}
+  end
+
+  def handle_call(:scoring, _from, game) do
+    {:reply, game.scoring, game}
   end
 
   def handle_call({:update, fun}, _from, state) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -104,6 +104,19 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), {:draw, {player_id, source}}, 5000)
   end
 
+  @doc """
+  Returns whether or not the specified game is finished.
+
+  ## Examples
+
+      iex> finished?("ABCD")
+      true
+  """
+  @spec finished?(Game.join_code()) :: boolean()
+  def finished?(join_code) do
+    GenServer.call(via(join_code), :finished?, 5000)
+  end
+
   @spec start_link({Game.join_code(), Player.t()}, GenServer.options()) :: on_start
   def start_link({join_code, player}, options \\ []) do
     GenServer.start_link(__MODULE__, {join_code, player}, options)
@@ -214,6 +227,10 @@ defmodule Level10.Games.GameServer do
 
       {:reply, new_card, game}
     end
+  end
+
+  def handle_call(:finished?, _from, game) do
+    {:reply, game.current_stage == :finish, game}
   end
 
   def handle_call({:get, fun}, _from, state) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -459,6 +459,14 @@ defmodule Level10.Games.GameServer do
     end
   end
 
+  @doc """
+  Update the specified game using the provided function.
+  """
+  @spec update(Game.join_code(), (Game.t() -> Game.t())) :: :ok
+  def update(join_code, fun) do
+    GenServer.call(via(join_code), {:update, fun}, 5000)
+  end
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -485,16 +493,6 @@ defmodule Level10.Games.GameServer do
   @spec get_and_update(agent, module, atom, [term], timeout) :: any
   def get_and_update(agent, module, fun, args, timeout \\ 5000) do
     GenServer.call(agent, {:get_and_update, {module, fun, args}}, timeout)
-  end
-
-  @spec update(agent, (state -> state), timeout) :: :ok
-  def update(agent, fun, timeout \\ 5000) when is_function(fun, 1) do
-    GenServer.call(agent, {:update, fun}, timeout)
-  end
-
-  @spec update(agent, module, atom, [term], timeout) :: :ok
-  def update(agent, module, fun, args, timeout \\ 5000) do
-    GenServer.call(agent, {:update, {module, fun, args}}, timeout)
   end
 
   @spec stop(agent, reason :: term, timeout) :: :ok

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -130,6 +130,22 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), :get, 5000)
   end
 
+  @doc """
+  Get the player whose turn it currently is.
+
+  ## Examples
+
+      iex> get_current_turn("ABCD")
+      %Player{id: "ffe6629a-faff-4053-b7b8-83c3a307400f", name: "Player 1"}
+  """
+  @spec get_current_turn(Game.join_code()) :: Player.t()
+  def get_current_turn(join_code) do
+    GenServer.call(via(join_code), :current_player, 5000)
+  end
+
+  # Old School Agent Functions
+  # TODO: Burn them all down :)
+
   @spec start_link({Game.join_code(), Player.t()}, GenServer.options()) :: on_start
   def start_link({join_code, player}, options \\ []) do
     GenServer.start_link(__MODULE__, {join_code, player}, options)
@@ -205,6 +221,10 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:creator, _from, game) do
     {:reply, Game.creator(game), game}
+  end
+
+  def handle_call(:current_player, _from, game) do
+    {:reply, game.current_player, game}
   end
 
   def handle_call(:current_turn_drawn?, _from, game) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -400,6 +400,14 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), :start_round, 5000)
   end
 
+  @doc """
+  Start the game.
+  """
+  @spec start_game(Game.join_code()) :: :ok | :single_player
+  def start_game(join_code) do
+    GenServer.call(via(join_code), :start_game, 5000)
+  end
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -534,7 +542,6 @@ defmodule Level10.Games.GameServer do
         {:reply, new_card, game}
 
       error ->
-        IO.inspect(error)
         {:reply, error, game}
     end
   end
@@ -633,6 +640,19 @@ defmodule Level10.Games.GameServer do
 
       :game_over ->
         {:reply, :game_over, game}
+    end
+  end
+
+  # TODO: Move to cast
+  def handle_call(:start_game, _from, game) do
+    case Game.start_game(game) do
+      {:ok, game} ->
+        Logger.info("Started game #{game.join_code}")
+        broadcast(game.join_code, :game_started, nil)
+        {:reply, :ok, game}
+
+      :single_player ->
+        {:reply, :single_player, game}
     end
   end
 

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -60,6 +60,19 @@ defmodule Level10.Games.GameServer do
   end
 
   @doc """
+  Delete a game.
+
+  ## Examples
+
+      iex> delete_game("ABCD")
+      :ok
+  """
+  @spec delete_game(Game.join_code(), reason :: term, timeout) :: :ok
+  def delete_game(join_code, reason \\ :normal, timeout \\ :infinity) do
+    GenServer.stop(via(join_code), reason, timeout)
+  end
+
+  @doc """
   Discard a card from the player's hand
 
   ## Examples

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -45,6 +45,14 @@ defmodule Level10.Games.GameServer do
   end
 
   @doc """
+  Send an update to all the subscribed processes
+  """
+  @spec broadcast(Game.join_code(), event_type(), term()) :: :ok | {:error, term()}
+  def broadcast(join_code, event_type, event) do
+    Phoenix.PubSub.broadcast(Level10.PubSub, "game:" <> join_code, {event_type, event})
+  end
+
+  @doc """
   Returns a Player struct representing the player who created the game.
   """
   @spec creator(Game.join_code()) :: Player.t()
@@ -346,6 +354,14 @@ defmodule Level10.Games.GameServer do
   def leave_game(join_code, player_id) do
     result = GenServer.call(via(join_code), {:delete_player, player_id}, 5000)
     with :empty_game <- result, do: delete_game(join_code)
+  end
+
+  @doc """
+  Get the list of players currently present in the specified game.
+  """
+  @spec list_presence(Game.join_code()) :: %{optional(Player.id()) => map()}
+  def list_presence(join_code) do
+    Presence.list("game:" <> join_code)
   end
 
   @doc """
@@ -766,11 +782,6 @@ defmodule Level10.Games.GameServer do
   end
 
   # Private Functions
-
-  @spec broadcast(Game.join_code(), event_type(), term()) :: :ok | {:error, term()}
-  def broadcast(join_code, event_type, event) do
-    Phoenix.PubSub.broadcast(Level10.PubSub, "game:" <> join_code, {event_type, event})
-  end
 
   @spec broadcast_game_complete(Game.t(), Player.id()) :: :ok | {:error, term()}
   defp broadcast_game_complete(game, player_id) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -237,6 +237,33 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), :scoring, 5000)
   end
 
+  @doc """
+  Get the table: the cards that have been played to complete levels by each
+  player.
+
+  ## Examples
+
+      iex> get_table("ABCD")
+      %{
+        "12a29ba6-fe6f-4f81-8c89-46ef8aff4b82" => %{
+          0 => [
+            %Level10.Games.Card{color: :black, value: :wild},
+            %Level10.Games.Card{color: :blue, value: :twelve},
+            %Level10.Games.Card{color: :red, value: :twelve}
+          ],
+          1 => [
+            %Level10.Games.Card{color: :black, value: :wild},
+            %Level10.Games.Card{color: :green, value: :ten},
+            %Level10.Games.Card{color: :blue, value: :ten}
+          ]
+        }
+      }
+  """
+  @spec get_table(Game.join_code()) :: Game.table()
+  def get_table(join_code) do
+    GenServer.call(via(join_code), :table, 5000)
+  end
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -401,6 +428,10 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:scoring, _from, game) do
     {:reply, game.scoring, game}
+  end
+
+  def handle_call(:table, _from, game) do
+    {:reply, game.table, game}
   end
 
   def handle_call({:update, fun}, _from, state) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -392,6 +392,14 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), :round_winner, 5000)
   end
 
+  @doc """
+  Start the next round.
+  """
+  @spec start_round(Game.join_code()) :: :ok | :game_over
+  def start_round(join_code) do
+    GenServer.call(via(join_code), :start_round, 5000)
+  end
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -614,6 +622,18 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:scoring, _from, game) do
     {:reply, game.scoring, game}
+  end
+
+  # TODO: Move to cast
+  def handle_call(:start_round, _from, game) do
+    case Game.start_round(game) do
+      {:ok, game} ->
+        broadcast(game.join_code, :round_started, nil)
+        {:reply, :ok, game}
+
+      :game_over ->
+        {:reply, :game_over, game}
+    end
   end
 
   def handle_call(:table, _from, game) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -264,6 +264,22 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), :table, 5000)
   end
 
+  @doc """
+  Get the top card from the discard pile.
+
+  ## Examples
+
+      iex> get_top_discarded_card("ABCD")
+      %Card{color: :green, value: :twelve}
+
+      iex> get_top_discarded_card("ABCD")
+      nil
+  """
+  @spec get_top_discarded_card(Game.join_code()) :: Card.t() | nil
+  def get_top_discarded_card(join_code) do
+    GenServer.call(via(join_code), :top_discarded_card, 5000)
+  end
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -432,6 +448,11 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:table, _from, game) do
     {:reply, game.table, game}
+  end
+
+  def handle_call(:top_discarded_card, _from, game) do
+    card = Game.top_discarded_card(game)
+    {:reply, card, game}
   end
 
   def handle_call({:update, fun}, _from, state) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -38,6 +38,14 @@ defmodule Level10.Games.GameServer do
     )
   end
 
+  @doc """
+  Returns a Player struct representing the player who created the game.
+  """
+  @spec creator(Game.join_code()) :: Player.t()
+  def creator(join_code) do
+    GenServer.call(via(join_code), :creator, 5000)
+  end
+
   @spec start_link({Game.join_code(), Player.t()}, GenServer.options()) :: on_start
   def start_link({join_code, player}, options \\ []) do
     GenServer.start_link(__MODULE__, {join_code, player}, options)
@@ -109,6 +117,10 @@ defmodule Level10.Games.GameServer do
       error ->
         {:reply, error, game}
     end
+  end
+
+  def handle_call(:creator, _from, game) do
+    {:reply, Game.creator(game), game}
   end
 
   def handle_call({:get, fun}, _from, state) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -105,6 +105,25 @@ defmodule Level10.Games.GameServer do
   end
 
   @doc """
+  Returns whether or not a game with the specified join code exists.
+
+  ## Examples
+
+      iex> exists?("ABCD")
+      true
+
+      iex> exists?("ASDF")
+      false
+  """
+  @spec exists?(Game.join_code()) :: boolean()
+  def exists?(join_code) do
+    case Horde.Registry.lookup(GameRegistry, join_code) do
+      [] -> false
+      _ -> true
+    end
+  end
+
+  @doc """
   Returns whether or not the specified game is finished.
 
   ## Examples

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -408,6 +408,22 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), :start_game, 5000)
   end
 
+  @doc """
+  Check whether or not a game has started.
+
+  ## Examples
+
+      iex> started?("ABCD")
+      true
+
+      iex> started?("EFGH")
+      false
+  """
+  @spec started?(Game.join_code()) :: boolean()
+  def started?(join_code) do
+    GenServer.call(via(join_code), :started?, 5000)
+  end
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -654,6 +670,10 @@ defmodule Level10.Games.GameServer do
       :single_player ->
         {:reply, :single_player, game}
     end
+  end
+
+  def handle_call(:started?, _from, game) do
+    {:reply, game.current_stage != :lobby, game}
   end
 
   def handle_call(:table, _from, game) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -213,6 +213,14 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), :players_ready, 5000)
   end
 
+  @doc """
+  Get the round number for the current round.
+  """
+  @spec get_round_number(Game.join_code()) :: non_neg_integer()
+  def get_round_number(join_code) do
+    GenServer.call(via(join_code), :current_round, 5000)
+  end
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -295,6 +303,10 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:current_player, _from, game) do
     {:reply, game.current_player, game}
+  end
+
+  def handle_call(:current_round, _from, game) do
+    {:reply, game.current_round, game}
   end
 
   def handle_call(:current_turn_drawn?, _from, game) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -117,6 +117,19 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), :finished?, 5000)
   end
 
+  @doc """
+  Returns the game with the specified join code.
+
+  ## Examples
+
+      iex> get("ABCD")
+      %Game{}
+  """
+  @spec get(Game.join_code()) :: Game.t()
+  def get(join_code) do
+    GenServer.call(via(join_code), :get, 5000)
+  end
+
   @spec start_link({Game.join_code(), Player.t()}, GenServer.options()) :: on_start
   def start_link({join_code, player}, options \\ []) do
     GenServer.start_link(__MODULE__, {join_code, player}, options)
@@ -231,6 +244,10 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:finished?, _from, game) do
     {:reply, game.current_stage == :finish, game}
+  end
+
+  def handle_call(:get, _from, game) do
+    {:reply, game, game}
   end
 
   def handle_call({:get, fun}, _from, state) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -143,6 +143,19 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), :current_player, 5000)
   end
 
+  @doc """
+  Get the count of cards in each player's hand.
+
+  ## Examples
+
+      iex> get_hand_counts("ABCD")
+      %{"179539f0-661e-4b56-ac67-fec916214223" => 10, "000cc69a-bb7d-4d3e-ae9f-e42e3dcac23e" => 3}
+  """
+  @spec get_hand_counts(Game.join_code()) :: %{optional(Player.id()) => non_neg_integer()}
+  def get_hand_counts(join_code) do
+    GenServer.call(via(join_code), :hand_counts, 5000)
+  end
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -279,6 +292,10 @@ defmodule Level10.Games.GameServer do
       {reply, state} -> {:reply, reply, state}
       other -> {:stop, {:bad_return_value, other}, state}
     end
+  end
+
+  def handle_call(:hand_counts, _from, game) do
+    {:reply, Game.hand_counts(game), game}
   end
 
   def handle_call({:update, fun}, _from, state) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -368,6 +368,22 @@ defmodule Level10.Games.GameServer do
 
   def player_exists?(game, player_id), do: Game.player_exists?(game, player_id)
 
+  @doc """
+  Check whether or not the current round has started.
+
+  ## Examples
+
+      iex> round_started?("ABCD")
+      true
+
+      iex> round_started?("EFGH")
+      false
+  """
+  @spec round_started?(Game.join_code()) :: boolean()
+  def round_started?(join_code) do
+    GenServer.call(via(join_code), :round_started?, 5000)
+  end
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -578,6 +594,10 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:players_ready, _from, game) do
     {:reply, game.players_ready, game}
+  end
+
+  def handle_call(:round_started?, _from, game) do
+    {:reply, game.current_stage == :play, game}
   end
 
   def handle_call(:scoring, _from, game) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -207,10 +207,6 @@ defmodule Level10.Games.GameServer do
     {:reply, card, game}
   end
 
-  def handle_call({:update, fun}, _from, state) do
-    {:reply, :ok, apply(fun, [state])}
-  end
-
   @impl true
   def handle_cast({:player_ready, player_id}, game) do
     with {:all_ready, game} <- Game.mark_player_ready(game, player_id),
@@ -238,6 +234,10 @@ defmodule Level10.Games.GameServer do
         broadcast(game.join_code, :start_error, :single_player)
         {:noreply, game}
     end
+  end
+
+  def handle_cast({:update, fun}, state) do
+    {:noreply, apply(fun, [state])}
   end
 
   # Handle exits whenever a name conflict occurs

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -189,6 +189,22 @@ defmodule Level10.Games.GameServer do
         do: {player_id, Levels.by_number(level_number)}
   end
 
+  @doc """
+  Get the list of players in a game.
+
+  ## Examples
+
+      iex> get_players("ABCD")
+      [
+        %Player{id: "601a07a1-b229-47e5-ad13-dbe0599c90e9", name: "Player 1"},
+        %Player{id: "a0d2ef3e-e44c-4a58-b90d-a56d88224700", name: "Player 2"}
+      ]
+  """
+  @spec get_players(Game.join_code()) :: list(Player.t())
+  def get_players(join_code) do
+    GenServer.call(via(join_code), :players, 5000)
+  end
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -337,6 +353,10 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:levels, _from, game) do
     {:reply, game.levels, game}
+  end
+
+  def handle_call(:players, _from, game) do
+    {:reply, game.players, game}
   end
 
   def handle_call({:update, fun}, _from, state) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -205,6 +205,14 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), :players, 5000)
   end
 
+  @doc """
+  Gets the set of IDs of players who are ready for the next round to begin.
+  """
+  @spec get_players_ready(Game.join_code()) :: MapSet.t(Player.id())
+  def get_players_ready(join_code) do
+    GenServer.call(via(join_code), :players_ready, 5000)
+  end
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -357,6 +365,10 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:players, _from, game) do
     {:reply, game.players, game}
+  end
+
+  def handle_call(:players_ready, _from, game) do
+    {:reply, game.players_ready, game}
   end
 
   def handle_call({:update, fun}, _from, state) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -156,6 +156,19 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), :hand_counts, 5000)
   end
 
+  @doc """
+  Get the hand of the specified player.
+
+  ## Examples
+
+      iex> get_hand_for_player("ABCD", "557489d0-1ef2-4763-9b0b-d2ea3c80fd99")
+      [%Card{color: :green, value: :twelve}, %Card{color: :blue, value: :nine}, ...]
+  """
+  @spec get_hand_for_player(Game.join_code(), Player.id()) :: list(Card.t())
+  def get_hand_for_player(join_code, player_id) do
+    GenServer.call(via(join_code), {:hand, player_id}, 5000)
+  end
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -296,6 +309,10 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:hand_counts, _from, game) do
     {:reply, Game.hand_counts(game), game}
+  end
+
+  def handle_call({:hand, player_id}, _from, game) do
+    {:reply, game.hands[player_id], game}
   end
 
   def handle_call({:update, fun}, _from, state) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -181,18 +181,6 @@ defmodule Level10.Games.GameServer do
     {:reply, game.scoring, game}
   end
 
-  # TODO: Move to cast
-  def handle_call(:start_round, _from, game) do
-    case Game.start_round(game) do
-      {:ok, game} ->
-        broadcast(game.join_code, :round_started, nil)
-        {:reply, :ok, game}
-
-      :game_over ->
-        {:reply, :game_over, game}
-    end
-  end
-
   def handle_call(:started?, _from, game) do
     {:reply, game.current_stage != :lobby, game}
   end

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -480,15 +480,20 @@ defmodule Level10.Games.GameServer do
   end
 
   def handle_call({:draw, {player_id, source}}, _from, game) do
-    with {:ok, game} <- Game.draw_card(game, player_id, source) do
-      if source == :discard_pile do
-        broadcast(game.join_code, :new_discard_top, Game.top_discarded_card(game))
-      end
+    case Game.draw_card(game, player_id, source) do
+      %Game{} = game ->
+        if source == :discard_pile do
+          broadcast(game.join_code, :new_discard_top, Game.top_discarded_card(game))
+        end
 
-      broadcast(game.join_code, :hand_counts_updated, Game.hand_counts(game))
-      [new_card | _] = game.hands[player_id]
+        broadcast(game.join_code, :hand_counts_updated, Game.hand_counts(game))
+        [new_card | _] = game.hands[player_id]
 
-      {:reply, new_card, game}
+        {:reply, new_card, game}
+
+      error ->
+        IO.inspect(error)
+        {:reply, error, game}
     end
   end
 

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -193,19 +193,6 @@ defmodule Level10.Games.GameServer do
     end
   end
 
-  # TODO: Move to cast
-  def handle_call(:start_game, _from, game) do
-    case Game.start_game(game) do
-      {:ok, game} ->
-        Logger.info("Started game #{game.join_code}")
-        broadcast(game.join_code, :game_started, nil)
-        {:reply, :ok, game}
-
-      :single_player ->
-        {:reply, :single_player, game}
-    end
-  end
-
   def handle_call(:started?, _from, game) do
     {:reply, game.current_stage != :lobby, game}
   end
@@ -248,6 +235,19 @@ defmodule Level10.Games.GameServer do
 
       {:ok, game} ->
         broadcast(game.join_code, :players_ready, game.players_ready)
+        {:noreply, game}
+    end
+  end
+
+  def handle_cast(:start_game, game) do
+    case Game.start_game(game) do
+      {:ok, game} ->
+        Logger.info("Started game #{game.join_code}")
+        broadcast(game.join_code, :game_started, nil)
+        {:noreply, game}
+
+      :single_player ->
+        broadcast(game.join_code, :start_error, :single_player)
         {:noreply, game}
     end
   end

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -1,542 +1,34 @@
 defmodule Level10.Games.GameServer do
   @moduledoc """
-  A server for holding game state
+  This module contains the logic for the servers that store the state of each
+  game.
+
+  Each server is initialized with an empty Game struct, and then messages sent
+  to the server will either read from that struct or manipulate it in different
+  ways.
+
+  This module should handle only the most basic logic, while
+  `Level10.Games.Game` will contain the logic for manipulating the game state.
   """
 
   use GenServer
-  alias Level10.{Presence, StateHandoff}
-  alias Level10.Games.{Game, GameRegistry, GameSupervisor, Levels, Player}
+  alias Level10.StateHandoff
+  alias Level10.Games.{Game, Player}
   require Logger
-
-  # Types
-
-  @typedoc "The agent reference"
-  @type agent :: pid | {atom, node} | name
-
-  @typedoc "The agent name"
-  @type name :: atom | {:global, term} | {:via, module, term}
 
   @typedoc "Return values of `start*` functions"
   @type on_start :: {:ok, pid} | {:error, {:already_started, pid} | term}
 
-  @typedoc "The agent state"
-  @type state :: term
-
   @typep event_type :: atom()
-  @typep game_name :: {:via, module, term}
 
-  # Constants
-
-  @max_creation_attempts 10
   @max_players 6
-
-  # Client Functions
-
-  @doc """
-  Add one or more cards to a group that is already on the table
-  """
-  @spec add_to_table(Game.join_code(), Player.id(), Player.id(), non_neg_integer(), Game.cards()) ::
-          :ok | :invalid_group | :level_incomplete | :needs_to_draw | :not_your_turn
-  def add_to_table(join_code, player_id, table_id, position, cards_to_add) do
-    GenServer.call(
-      via(join_code),
-      {:add_to_table, {player_id, table_id, position, cards_to_add}},
-      5000
-    )
-  end
-
-  @doc """
-  Send an update to all the subscribed processes
-  """
-  @spec broadcast(Game.join_code(), event_type(), term()) :: :ok | {:error, term()}
-  def broadcast(join_code, event_type, event) do
-    Phoenix.PubSub.broadcast(Level10.PubSub, "game:" <> join_code, {event_type, event})
-  end
-
-  @doc """
-  Get the current count of active games in play.
-  """
-  @spec count() :: non_neg_integer()
-  def count() do
-    %{active: count} = Supervisor.count_children(GameSupervisor)
-    count
-  end
-
-  @doc """
-  Create a new game with the player named as its creator.
-  """
-  @spec create_game(String.t()) :: {:ok, Game.join_code(), Player.id()} | :error
-  def create_game(player_name) do
-    player = Player.new(player_name)
-    do_create_game(player, @max_creation_attempts)
-  end
-
-  @doc """
-  Returns a Player struct representing the player who created the game.
-  """
-  @spec creator(Game.join_code()) :: Player.t()
-  def creator(join_code) do
-    GenServer.call(via(join_code), :creator, 5000)
-  end
-
-  @doc """
-  Check to see if the current player has drawn a card yet.
-
-  ## Examples
-
-      iex> current_player_has_drawn?("ABCD")
-      true
-  """
-  @spec current_player_has_drawn?(Game.join_code()) :: boolean()
-  def current_player_has_drawn?(join_code) do
-    GenServer.call(via(join_code), :current_turn_drawn?, 5000)
-  end
-
-  @doc """
-  Delete a game.
-
-  ## Examples
-
-      iex> delete_game("ABCD")
-      :ok
-  """
-  @spec delete_game(Game.join_code(), reason :: term, timeout) :: :ok
-  def delete_game(join_code, reason \\ :normal, timeout \\ :infinity) do
-    GenServer.stop(via(join_code), reason, timeout)
-  end
-
-  @doc """
-  Discard a card from the player's hand
-
-  ## Examples
-
-      iex> discard_card("ABCD", "9c34b9fe-3104-44b3-b21b-28140e2e3624", %Card{color: :green, value: :twelve})
-      :ok
-  """
-  @spec discard_card(Game.join_code(), Player.id(), Card.t()) ::
-          :ok | :needs_to_draw | :not_your_turn
-  def discard_card(join_code, player_id, card) do
-    GenServer.call(via(join_code), {:discard, {player_id, card}}, 5000)
-  end
-
-  @doc """
-  Take the top card from either the draw pile or discard pile and add it to the
-  player's hand
-
-  ## Examples
-
-      iex> draw_card("ABCD", "9c34b9fe-3104-44b3-b21b-28140e2e3624", :draw_pile)
-      %Card{color: :green, value: :twelve}
-
-      iex> draw_card("ABCD", "9c34b9fe-3104-44b3-b21b-28140e2e3624", :discard_pile)
-      %Card{color: :green, value: :twelve}
-  """
-  @spec draw_card(Game.join_code(), Player.id(), :discard_pile | :draw_pile) ::
-          Card.t() | :already_drawn | :empty_discard_pile | :not_your_turn | :skip
-  def draw_card(join_code, player_id, source) do
-    GenServer.call(via(join_code), {:draw, {player_id, source}}, 5000)
-  end
-
-  @doc """
-  Returns whether or not a game with the specified join code exists.
-
-  ## Examples
-
-      iex> exists?("ABCD")
-      true
-
-      iex> exists?("ASDF")
-      false
-  """
-  @spec exists?(Game.join_code()) :: boolean()
-  def exists?(join_code) do
-    case Horde.Registry.lookup(GameRegistry, join_code) do
-      [] -> false
-      _ -> true
-    end
-  end
-
-  @doc """
-  Returns whether or not the specified game is finished.
-
-  ## Examples
-
-      iex> finished?("ABCD")
-      true
-  """
-  @spec finished?(Game.join_code()) :: boolean()
-  def finished?(join_code) do
-    GenServer.call(via(join_code), :finished?, 5000)
-  end
-
-  @doc """
-  Returns the game with the specified join code.
-
-  ## Examples
-
-      iex> get("ABCD")
-      %Game{}
-  """
-  @spec get(Game.join_code()) :: Game.t()
-  def get(join_code) do
-    GenServer.call(via(join_code), :get, 5000)
-  end
-
-  @doc """
-  Get the player whose turn it currently is.
-
-  ## Examples
-
-      iex> get_current_turn("ABCD")
-      %Player{id: "ffe6629a-faff-4053-b7b8-83c3a307400f", name: "Player 1"}
-  """
-  @spec get_current_turn(Game.join_code()) :: Player.t()
-  def get_current_turn(join_code) do
-    GenServer.call(via(join_code), :current_player, 5000)
-  end
-
-  @doc """
-  Get the count of cards in each player's hand.
-
-  ## Examples
-
-      iex> get_hand_counts("ABCD")
-      %{"179539f0-661e-4b56-ac67-fec916214223" => 10, "000cc69a-bb7d-4d3e-ae9f-e42e3dcac23e" => 3}
-  """
-  @spec get_hand_counts(Game.join_code()) :: %{optional(Player.id()) => non_neg_integer()}
-  def get_hand_counts(join_code) do
-    GenServer.call(via(join_code), :hand_counts, 5000)
-  end
-
-  @doc """
-  Get the hand of the specified player.
-
-  ## Examples
-
-      iex> get_hand_for_player("ABCD", "557489d0-1ef2-4763-9b0b-d2ea3c80fd99")
-      [%Card{color: :green, value: :twelve}, %Card{color: :blue, value: :nine}, ...]
-  """
-  @spec get_hand_for_player(Game.join_code(), Player.id()) :: list(Card.t())
-  def get_hand_for_player(join_code, player_id) do
-    GenServer.call(via(join_code), {:hand, player_id}, 5000)
-  end
-
-  @doc """
-  Get the level information for each player in the game.
-
-  ## Examples
-
-      iex> get_levels("ABCD")
-      %{
-        "04ba446e-0b2a-49f2-8dbf-7d9742548842" => [set: 4, run: 4],
-        "86800484-8e73-4408-bd15-98a57871694f" => [run: 7],
-      }
-  """
-  @spec get_levels(Game.join_code()) :: %{optional(Player.t()) => Levels.level()}
-  def get_levels(join_code) do
-    levels = GenServer.call(via(join_code), :levels, 5000)
-
-    for {player_id, level_number} <- levels,
-        into: %{},
-        do: {player_id, Levels.by_number(level_number)}
-  end
-
-  @doc """
-  Get the list of players in a game.
-
-  ## Examples
-
-      iex> get_players("ABCD")
-      [
-        %Player{id: "601a07a1-b229-47e5-ad13-dbe0599c90e9", name: "Player 1"},
-        %Player{id: "a0d2ef3e-e44c-4a58-b90d-a56d88224700", name: "Player 2"}
-      ]
-  """
-  @spec get_players(Game.join_code()) :: list(Player.t())
-  def get_players(join_code) do
-    GenServer.call(via(join_code), :players, 5000)
-  end
-
-  @doc """
-  Gets the set of IDs of players who are ready for the next round to begin.
-  """
-  @spec get_players_ready(Game.join_code()) :: MapSet.t(Player.id())
-  def get_players_ready(join_code) do
-    GenServer.call(via(join_code), :players_ready, 5000)
-  end
-
-  @doc """
-  Get the round number for the current round.
-  """
-  @spec get_round_number(Game.join_code()) :: non_neg_integer()
-  def get_round_number(join_code) do
-    GenServer.call(via(join_code), :current_round, 5000)
-  end
-
-  @doc """
-  Get the scores for all players in a game.
-
-  ## Examples
-
-      iex> get_scores("ABCD")
-      %{
-        "e486056e-4a01-4239-9f00-6f7f57ca8d54" => {3, 55},
-        "38379e46-4d29-4a22-a245-aa7013ec3c33" => {2, 120}
-      }
-  """
-  @spec get_scores(Game.join_code()) :: Game.scores()
-  def get_scores(join_code) do
-    GenServer.call(via(join_code), :scoring, 5000)
-  end
-
-  @doc """
-  Get the table: the cards that have been played to complete levels by each
-  player.
-
-  ## Examples
-
-      iex> get_table("ABCD")
-      %{
-        "12a29ba6-fe6f-4f81-8c89-46ef8aff4b82" => %{
-          0 => [
-            %Level10.Games.Card{color: :black, value: :wild},
-            %Level10.Games.Card{color: :blue, value: :twelve},
-            %Level10.Games.Card{color: :red, value: :twelve}
-          ],
-          1 => [
-            %Level10.Games.Card{color: :black, value: :wild},
-            %Level10.Games.Card{color: :green, value: :ten},
-            %Level10.Games.Card{color: :blue, value: :ten}
-          ]
-        }
-      }
-  """
-  @spec get_table(Game.join_code()) :: Game.table()
-  def get_table(join_code) do
-    GenServer.call(via(join_code), :table, 5000)
-  end
-
-  @doc """
-  Get the top card from the discard pile.
-
-  ## Examples
-
-      iex> get_top_discarded_card("ABCD")
-      %Card{color: :green, value: :twelve}
-
-      iex> get_top_discarded_card("ABCD")
-      nil
-  """
-  @spec get_top_discarded_card(Game.join_code()) :: Card.t() | nil
-  def get_top_discarded_card(join_code) do
-    GenServer.call(via(join_code), :top_discarded_card, 5000)
-  end
-
-  @doc """
-  Attempts to join a game. Will return an ok tuple with the player ID for the
-  new player if joining is successful, or an atom with a reason if not.
-
-  ## Examples
-
-      iex> join_game("ABCD", "Player One")
-      {:ok, "9bbfeacb-a006-4646-8776-83cca0ad03eb"}
-
-      iex> join_game("ABCD", "Player One")
-      :already_started
-
-      iex> join_game("ABCD", "Player One")
-      :full
-
-      iex> join_game("ABCD", "Player One")
-      :not_found
-  """
-  @spec join_game(Game.join_code(), String.t()) ::
-          {:ok, Player.id()} | :already_started | :full | :not_found
-  def join_game(join_code, player_name) do
-    player = Player.new(player_name)
-
-    if exists?(join_code) do
-      GenServer.call(via(join_code), {:join, player}, 5000)
-    else
-      :not_found
-    end
-  end
-
-  @doc """
-  Removes the specified player from the game. This is only allowed if the game
-  is still in the lobby stage.
-
-  If the player is currently alone in the game, the game will be deleted as
-  well.
-  """
-  @spec leave_game(Game.join_code(), Player.id()) :: :ok | :already_started | :deleted
-  def leave_game(join_code, player_id) do
-    result = GenServer.call(via(join_code), {:delete_player, player_id}, 5000)
-    with :empty_game <- result, do: delete_game(join_code)
-  end
-
-  @doc """
-  Get the list of players currently present in the specified game.
-  """
-  @spec list_presence(Game.join_code()) :: %{optional(Player.id()) => map()}
-  def list_presence(join_code) do
-    Presence.list("game:" <> join_code)
-  end
-
-  @doc """
-  Stores in the game state that the specified player is ready to move on to the
-  next stage of the game.
-  """
-  @spec mark_player_ready(Game.join_code(), Player.id()) :: :ok
-  def mark_player_ready(join_code, player_id) do
-    result = GenServer.call(via(join_code), {:player_ready, player_id}, 5000)
-    with :game_over <- result, do: delete_game(join_code)
-  end
-
-  @doc """
-  Returns whether or not the specified player exists within the specified game.
-  """
-  @spec player_exists?(Game.t() | Game.join_code(), Player.id()) :: boolean()
-  def player_exists?(join_code, player_id) when is_binary(join_code) do
-    GenServer.call(via(join_code), {:player_exists?, player_id}, 5000)
-  end
-
-  def player_exists?(game, player_id), do: Game.player_exists?(game, player_id)
-
-  @doc """
-  Check whether or not the current round has started.
-
-  ## Examples
-
-      iex> round_started?("ABCD")
-      true
-
-      iex> round_started?("EFGH")
-      false
-  """
-  @spec round_started?(Game.join_code()) :: boolean()
-  def round_started?(join_code) do
-    GenServer.call(via(join_code), :round_started?, 5000)
-  end
-
-  @doc """
-  Returns the player struct representing the player who won the current round.
-  """
-  @spec round_winner(Game.join_code()) :: Player.t() | nil
-  def round_winner(join_code) do
-    GenServer.call(via(join_code), :round_winner, 5000)
-  end
-
-  @doc """
-  Start the next round.
-  """
-  @spec start_round(Game.join_code()) :: :ok | :game_over
-  def start_round(join_code) do
-    GenServer.call(via(join_code), :start_round, 5000)
-  end
-
-  @doc """
-  Start the game.
-  """
-  @spec start_game(Game.join_code()) :: :ok | :single_player
-  def start_game(join_code) do
-    GenServer.call(via(join_code), :start_game, 5000)
-  end
-
-  @doc """
-  Check whether or not a game has started.
-
-  ## Examples
-
-      iex> started?("ABCD")
-      true
-
-      iex> started?("EFGH")
-      false
-  """
-  @spec started?(Game.join_code()) :: boolean()
-  def started?(join_code) do
-    GenServer.call(via(join_code), :started?, 5000)
-  end
-
-  @doc """
-  Susbscribe a process to updates for the specified game.
-  """
-  @spec subscribe(String.t(), Player.id()) :: :ok | {:error, term()}
-  def subscribe(game_code, player_id) do
-    topic = "game:" <> game_code
-
-    with :ok <- Phoenix.PubSub.subscribe(Level10.PubSub, topic),
-         {:ok, _} <- Presence.track_player(game_code, player_id) do
-      Presence.track_user(player_id, game_code)
-      :ok
-    end
-  end
-
-  @doc """
-  Set the given player's table to the given cards.
-  """
-  @spec table_cards(Game.join_code(), Player.id(), Game.player_table()) ::
-          :ok | :already_set | :needs_to_draw | :not_your_turn
-  def table_cards(join_code, player_id, player_table) do
-    GenServer.call(via(join_code), {:table_cards, {player_id, player_table}}, 5000)
-  end
-
-  @doc """
-  Unsubscribe a process from updates for the specified game.
-  """
-  @spec unsubscribe(String.t(), Player.id()) :: :ok | {:error, term()}
-  def unsubscribe(game_code, player_id) do
-    topic = "game:" <> game_code
-
-    with :ok <- Phoenix.PubSub.unsubscribe(Level10.PubSub, topic) do
-      Presence.untrack(self(), topic, player_id)
-    end
-  end
-
-  @doc """
-  Update the specified game using the provided function.
-  """
-  @spec update(Game.join_code(), (Game.t() -> Game.t())) :: :ok
-  def update(join_code, fun) do
-    GenServer.call(via(join_code), {:update, fun}, 5000)
-  end
-
-  # Old School Agent Functions
-  # TODO: Burn them all down :)
 
   @spec start_link({Game.join_code(), Player.t()}, GenServer.options()) :: on_start
   def start_link({join_code, player}, options \\ []) do
     GenServer.start_link(__MODULE__, {join_code, player}, options)
   end
 
-  @spec get(agent, (state -> a), timeout) :: a when a: var
-  def get(agent, fun, timeout \\ 5000) when is_function(fun, 1) do
-    GenServer.call(agent, {:get, fun}, timeout)
-  end
-
-  @spec get(agent, module, atom, [term], timeout) :: any
-  def get(agent, module, fun, args, timeout \\ 5000) do
-    GenServer.call(agent, {:get, {module, fun, args}}, timeout)
-  end
-
-  @spec get_and_update(agent, (state -> {a, state}), timeout) :: a when a: var
-  def get_and_update(agent, fun, timeout \\ 5000) when is_function(fun, 1) do
-    GenServer.call(agent, {:get_and_update, fun}, timeout)
-  end
-
-  @spec get_and_update(agent, module, atom, [term], timeout) :: any
-  def get_and_update(agent, module, fun, args, timeout \\ 5000) do
-    GenServer.call(agent, {:get_and_update, {module, fun, args}}, timeout)
-  end
-
-  @spec stop(agent, reason :: term, timeout) :: :ok
-  def stop(agent, reason \\ :normal, timeout \\ :infinity) do
-    GenServer.stop(agent, reason, timeout)
-  end
-
-  # Server Functions (Internal Use Only)
-
+  @impl true
   def init({join_code, player}) do
     Process.flag(:trap_exit, true)
     Process.put(:"$initial_call", {Game, :new, 2})
@@ -555,6 +47,7 @@ defmodule Level10.Games.GameServer do
     {:ok, game}
   end
 
+  @impl true
   def handle_call({:add_to_table, {player_id, table_id, position, cards_to_add}}, _from, game) do
     case Game.add_to_table(game, player_id, table_id, position, cards_to_add) do
       {:ok, game} ->
@@ -636,17 +129,6 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:get, _from, game) do
     {:reply, game, game}
-  end
-
-  def handle_call({:get, fun}, _from, state) do
-    {:reply, run(fun, [state]), state}
-  end
-
-  def handle_call({:get_and_update, fun}, _from, state) do
-    case run(fun, [state]) do
-      {reply, state} -> {:reply, reply, state}
-      other -> {:stop, {:bad_return_value, other}, state}
-    end
   end
 
   def handle_call(:hand_counts, _from, game) do
@@ -767,20 +249,11 @@ defmodule Level10.Games.GameServer do
   end
 
   def handle_call({:update, fun}, _from, state) do
-    {:reply, :ok, run(fun, [state])}
+    {:reply, :ok, apply(fun, [state])}
   end
 
-  def handle_cast({:cast, fun}, state) do
-    {:noreply, run(fun, [state])}
-  end
-
-  def code_change(_old, state, fun) do
-    {:ok, run(fun, [state])}
-  end
-
-  defp run({m, f, a}, extra), do: apply(m, f, extra ++ a)
-  defp run(fun, extra), do: apply(fun, extra)
-
+  # Handle exits whenever a name conflict occurs
+  @impl true
   def handle_info({:EXIT, _pid, {:name_conflict, _, _, _}}, game), do: {:stop, :shutdown, game}
 
   def handle_info(message, %{join_code: join_code} = game) do
@@ -790,6 +263,7 @@ defmodule Level10.Games.GameServer do
 
   # Matches whenever we manually stop a server since we don't need to move that
   # state to a new node
+  @impl true
   def terminate(:normal, _game), do: :ok
 
   # Called when a SIGTERM is received to begin the handoff process for moving
@@ -802,6 +276,11 @@ defmodule Level10.Games.GameServer do
 
   # Private Functions
 
+  @spec broadcast(Game.join_code(), event_type(), term()) :: :ok | {:error, term()}
+  defp broadcast(join_code, event_type, event) do
+    Phoenix.PubSub.broadcast(Level10.PubSub, "game:" <> join_code, {event_type, event})
+  end
+
   @spec broadcast_game_complete(Game.t(), Player.id()) :: :ok | {:error, term()}
   defp broadcast_game_complete(game, player_id) do
     player = Enum.find(game.players, &(&1.id == player_id))
@@ -812,33 +291,6 @@ defmodule Level10.Games.GameServer do
   defp broadcast_round_complete(game, player_id) do
     player = Enum.find(game.players, &(&1.id == player_id))
     broadcast(game.join_code, :round_finished, player)
-  end
-
-  @spec do_create_game(Player.t(), non_neg_integer()) ::
-          {:ok, Game.join_code(), Player.id()} | :error
-  defp do_create_game(player, attempts_remaining)
-
-  defp do_create_game(_player, 0) do
-    :error
-  end
-
-  defp do_create_game(player, attempts_remaining) do
-    join_code = Game.generate_join_code()
-
-    game = %{
-      id: join_code,
-      start: {__MODULE__, :start_link, [{join_code, player}, [name: via(join_code)]]},
-      restart: :temporary
-    }
-
-    case Horde.DynamicSupervisor.start_child(GameSupervisor, game) do
-      {:ok, _pid} ->
-        Logger.info(["Created game ", join_code])
-        {:ok, join_code, player.id}
-
-      {:error, {:already_started, _pid}} ->
-        do_create_game(player, attempts_remaining - 1)
-    end
   end
 
   @spec maybe_complete_round(Game.t(), Player.id()) :: Game.t()
@@ -855,10 +307,5 @@ defmodule Level10.Games.GameServer do
         broadcast_round_complete(game, player_id)
         game
     end
-  end
-
-  @spec via(Game.join_code()) :: game_name()
-  defp via(join_code) do
-    {:via, Horde.Registry, {GameRegistry, join_code}}
   end
 end

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -46,6 +46,19 @@ defmodule Level10.Games.GameServer do
     GenServer.call(via(join_code), :creator, 5000)
   end
 
+  @doc """
+  Check to see if the current player has drawn a card yet.
+
+  ## Examples
+
+      iex> current_player_has_drawn?("ABCD")
+      true
+  """
+  @spec current_player_has_drawn?(Game.join_code()) :: boolean()
+  def current_player_has_drawn?(join_code) do
+    GenServer.call(via(join_code), :current_turn_drawn?, 5000)
+  end
+
   @spec start_link({Game.join_code(), Player.t()}, GenServer.options()) :: on_start
   def start_link({join_code, player}, options \\ []) do
     GenServer.start_link(__MODULE__, {join_code, player}, options)
@@ -121,6 +134,10 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:creator, _from, game) do
     {:reply, Game.creator(game), game}
+  end
+
+  def handle_call(:current_turn_drawn?, _from, game) do
+    {:reply, game.current_turn_drawn?, game}
   end
 
   def handle_call({:get, fun}, _from, state) do

--- a/lib/level10/games/game_server.ex
+++ b/lib/level10/games/game_server.ex
@@ -358,6 +358,16 @@ defmodule Level10.Games.GameServer do
     with :game_over <- result, do: delete_game(join_code)
   end
 
+  @doc """
+  Returns whether or not the specified player exists within the specified game.
+  """
+  @spec player_exists?(Game.t() | Game.join_code(), Player.id()) :: boolean()
+  def player_exists?(join_code, player_id) when is_binary(join_code) do
+    GenServer.call(via(join_code), {:player_exists?, player_id}, 5000)
+  end
+
+  def player_exists?(game, player_id), do: Game.player_exists?(game, player_id)
+
   # Old School Agent Functions
   # TODO: Burn them all down :)
 
@@ -540,6 +550,10 @@ defmodule Level10.Games.GameServer do
 
   def handle_call(:levels, _from, game) do
     {:reply, game.levels, game}
+  end
+
+  def handle_call({:player_exists?, player_id}, _from, game) do
+    {:reply, Game.player_exists?(game, player_id), game}
   end
 
   def handle_call(:players, _from, game) do

--- a/lib/level10_web/live/game_live.ex
+++ b/lib/level10_web/live/game_live.ex
@@ -134,9 +134,10 @@ defmodule Level10Web.GameLive do
         "discard_pile" -> :discard_pile
       end
 
-    with %Card{} = new_card <- Games.draw_card(assigns.join_code, player_id, source) do
-      {:noreply, assign(socket, hand: [new_card | assigns.hand], has_drawn_card: true)}
-    else
+    case Games.draw_card(assigns.join_code, player_id, source) do
+      %Card{} = new_card ->
+        {:noreply, assign(socket, hand: [new_card | assigns.hand], has_drawn_card: true)}
+
       error ->
         message =
           case error do
@@ -148,9 +149,6 @@ defmodule Level10Web.GameLive do
           end
 
         {:noreply, flash_error(socket, message)}
-
-      _ ->
-        {:noreply, socket}
     end
   end
 

--- a/lib/level10_web/live/lobby_live.ex
+++ b/lib/level10_web/live/lobby_live.ex
@@ -167,22 +167,8 @@ defmodule Level10Web.LobbyLive do
   end
 
   def handle_event("start_game", _params, socket) do
-    case Games.start_game(socket.assigns.join_code) do
-      :single_player ->
-        Logger.warn("User tried to start game #{socket.assigns.join_code} with no other players")
-
-        socket =
-          put_flash(
-            socket,
-            :error,
-            "At least 2 players are needed to play Level 10. Time to make some friends! 😘"
-          )
-
-        {:noreply, socket}
-
-      :ok ->
-        {:noreply, assign(socket, starting: true)}
-    end
+    Games.start_game(socket.assigns.join_code)
+    {:noreply, assign(socket, starting: true)}
   end
 
   def handle_event("validate", %{"info" => info}, socket) do
@@ -204,6 +190,17 @@ defmodule Level10Web.LobbyLive do
     creator = List.last(players)
     is_creator = creator.id == socket.assigns.player_id
     {:noreply, assign(socket, is_creator: is_creator, players: players)}
+  end
+
+  def handle_info({:start_error, error}, socket) do
+    message =
+      case error do
+        :single_player ->
+          "At least 2 players are needed to play Level 10. Time to make some friends! 😘"
+      end
+
+    socket = assign(socket, starting: false)
+    {:noreply, put_flash(socket, :error, message)}
   end
 
   def handle_info(%{event: "presence_diff"}, socket) do


### PR DESCRIPTION
Currently game state is being stored in a somewhat customized Agent. This PR moves that state into a fully custom, vanilla Genserver.

Agents are great for storing state, but the customization was necessary when I wanted to implement custom termination logic. And with this change, the logic between server and client is able to be more fully separated so that it's more obvious what is running in the server versus what is running in the LiveView (and later channel) process. This will allow me to create more formal boundaries between domains.

Resolves #51 