### PR TITLE
Setting max age for session cookie

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :level10, Level10Web.Endpoint,
-  url: [host: "localhost", port: 443, scheme: "https"],
+  url: [port: 443, scheme: "https"],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 config :logger, level: :info

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :level10, Level10Web.Endpoint,
-  url: [port: 443, scheme: "https"],
-  cache_static_manifest: "priv/static/cache_manifest.json"
+  http: [port: 4002],
+  server: false
 
 config :logger, level: :info

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :level10, Level10Web.Endpoint,
-  url: [port: 443, scheme: "https"],
+  url: [host: "localhost", port: 443, scheme: "https"],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 config :logger, level: :info

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :level10, Level10Web.Endpoint,
-  http: [port: 4002],
-  server: false
+  url: [port: 443, scheme: "https"],
+  cache_static_manifest: "priv/static/cache_manifest.json"
 
 config :logger, level: :info

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :level10, Level10Web.Endpoint,
-  url: [host: "level10.games", port: 443, scheme: "https"],
+  url: [host: "localhost", port: 443, scheme: "https"],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 config :logger, level: :info

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -16,7 +16,7 @@ case config_env() do
 
     config :level10, Level10Web.Endpoint, server: true
 
-    app_name = System.get_env("FLY_APP_NAME") || raise "FLY_APP_NAME not available"
+    app_name = 'level10'
 
     # Configure clustering
     config :level10,
@@ -44,16 +44,11 @@ case config_env() do
       team_id: team_id
 
     admin_username =
-      System.get_env("ADMIN_USERNAME") ||
-        raise """
-        environment variable ADMIN_USERNAME is missing.
-        """
+      'admin'
 
     admin_password =
       System.get_env("ADMIN_PASSWORD") ||
-        raise """
-        environment variable ADMIN_PASSWORD is missing.
-        """
+        'password'
 
     # Replace default credentials for the live dashboard
     config :level10,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -14,7 +14,7 @@ case config_env() do
 
     config :level10, Level10Web.Endpoint, server: true
 
-    app_name = 'level10'
+    app_name = 'orca-app'
 
     # Configure clustering
     config :level10,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,8 +1,6 @@
 import Config
 
-key = '1010'
-key_identifier = '1010'
-team_id = '1010'
+
 
 case config_env() do
   :prod ->
@@ -32,15 +30,9 @@ case config_env() do
       ]
 
     # Configure push notifications
-    disabled = is_nil(key) || is_nil(key_identifier) || is_nil(team_id)
+    
 
-    config :level10, Level10.PushNotifications.APNS,
-      adapter: Pigeon.APNS,
-      disabled?: disabled,
-      key: key,
-      key_identifier: key_identifier,
-      mode: :dev,
-      team_id: team_id
+    config :level10, Level10.PushNotifications.APNS, disabled?: true
 
     admin_username =
       'admin'
@@ -59,13 +51,7 @@ case config_env() do
   :dev ->
     disabled = is_nil(key) || is_nil(key_identifier) || is_nil(team_id)
 
-    config :level10, Level10.PushNotifications.APNS,
-      adapter: Pigeon.APNS,
-      disabled?: disabled,
-      key: key,
-      key_identifier: key_identifier,
-      mode: :dev,
-      team_id: team_id
+    config :level10, Level10.PushNotifications.APNS, disabled?: true
 
   :test ->
     config :level10, Level10.PushNotifications.APNS, disabled?: true

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -14,20 +14,8 @@ case config_env() do
 
     config :level10, Level10Web.Endpoint, server: true
 
-    app_name = 'orca-app'
+  
 
-    # Configure clustering
-    config :level10,
-      cluster_topologies: [
-        level10: [
-          strategy: Cluster.Strategy.DNSPoll,
-          config: [
-            polling_interval: 5_000,
-            query: "#{app_name}.internal",
-            node_basename: app_name
-          ]
-        ]
-      ]
 
     # Configure push notifications
     

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,8 +1,8 @@
 import Config
 
-key = System.get_env("APNS_KEY")
-key_identifier = System.get_env("APNS_KEY_ID")
-team_id = System.get_env("APNS_TEAM_ID")
+key = '1010'
+key_identifier = '1010'
+team_id = '1010'
 
 case config_env() do
   :prod ->

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -6,12 +6,7 @@ team_id = System.get_env("APNS_TEAM_ID")
 
 case config_env() do
   :prod ->
-    secret_key_base =
-      System.get_env("SECRET_KEY_BASE") ||
-        raise """
-        environment variable SECRET_KEY_BASE is missing.
-        You can generate one by calling: mix phx.gen.secret
-        """
+    secret_key_base = 'bCIa/PcHlRstP+RwqTtHRgqQwVF97SeHa2GXL0UEOh3IRBLayk6QpomaGICfTCPM'
 
     config :level10, Level10Web.Endpoint,
       http: [

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -32,15 +32,14 @@ case config_env() do
       ]
 
     # Configure push notifications
-    if is_nil(key), do: raise("environment variable APNS_KEY is missing.")
-    if is_nil(key_identifier), do: raise("environment variable APNS_KEY_ID is missing.")
-    if is_nil(team_id), do: raise("environment variable APNS_TEAM_ID is missing.")
+    disabled = is_nil(key) || is_nil(key_identifier) || is_nil(team_id)
 
     config :level10, Level10.PushNotifications.APNS,
       adapter: Pigeon.APNS,
+      disabled?: disabled,
       key: key,
       key_identifier: key_identifier,
-      mode: :prod,
+      mode: :dev,
       team_id: team_id
 
     admin_username =

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -49,8 +49,6 @@ case config_env() do
       ]
 
   :dev ->
-    disabled = is_nil(key) || is_nil(key_identifier) || is_nil(team_id)
-
     config :level10, Level10.PushNotifications.APNS, disabled?: true
 
   :test ->

--- a/lib/level10_web/endpoint.ex
+++ b/lib/level10_web/endpoint.ex
@@ -6,7 +6,6 @@ defmodule Level10Web.Endpoint do
   # Set :encryption_salt if you would also like to encrypt it.
   @session_options [
     store: :cookie,
-	max_age: 9999999999,
     key: "_level10_key",
     signing_salt: "jmi0sffy"
   ]

--- a/lib/level10_web/endpoint.ex
+++ b/lib/level10_web/endpoint.ex
@@ -6,6 +6,7 @@ defmodule Level10Web.Endpoint do
   # Set :encryption_salt if you would also like to encrypt it.
   @session_options [
     store: :cookie,
+	max_age: 9999999999,
     key: "_level10_key",
     signing_salt: "jmi0sffy"
   ]

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-ip=$(grep fly-local-6pn /etc/hosts | cut -f 1)
-export RELEASE_DISTRIBUTION=name
-export RELEASE_NODE=$FLY_APP_NAME@$ip
+#ip=$(grep fly-local-6pn /etc/hosts | cut -f 1)
+#export RELEASE_DISTRIBUTION=name
+#export RELEASE_NODE=$FLY_APP_NAME@$ip


### PR DESCRIPTION
To fix session timing out- I was working on storing a user_id cookie to the user device and retrieving it, instead of generating a new one. I discovered through testing, that setting the existing session cookie max age in the endpoint does this automatically.